### PR TITLE
Check for authorization header.

### DIFF
--- a/spec/dummy/app/api/api.rb
+++ b/spec/dummy/app/api/api.rb
@@ -26,5 +26,10 @@ class API < Grape::API
     request.params.as_json
   end
 
+  desc 'Return oauth2 token', authorizations: { oauth2: [] }
+  get '/oauth2' do
+    request.headers.slice('Authorization').as_json
+  end
+
   add_swagger_documentation
 end

--- a/spec/features/swagger_spec.rb
+++ b/spec/features/swagger_spec.rb
@@ -89,6 +89,23 @@ describe 'Swagger' do
         expect(page).to have_css 'span.string', text: 'dummy'
       end
     end
+    context '#api_auth:oauth2' do
+      before do
+        GrapeSwaggerRails.options.api_auth = 'bearer'
+        GrapeSwaggerRails.options.api_key_name = 'Authorization'
+        GrapeSwaggerRails.options.api_key_type = 'header'
+        visit '/swagger'
+      end
+      it 'adds a token when the route specifies oauth2 authorization' do
+        page.execute_script("$('#input_apiKey').val('token')")
+        page.execute_script("$('#input_apiKey').trigger('change')")
+        find('#endpointListTogger_oauth2', visible: true).click
+        first('a[href="#!/oauth2/GET_api_oauth2_format"]', visible: true).click
+        click_button 'Try it out!'
+        expect(page).to have_css 'span.attribute', text: 'Authorization'
+        expect(page).to have_css 'span.string', text: 'Bearer token'
+      end
+    end
     context '#before_filter' do
       before do
         GrapeSwaggerRails.options.before_filter do |_request|


### PR DESCRIPTION
It appears that Swagger-UI correctly sets an authorization header when
added in the interface (api key field). However, if the endpoint has
the option "authorizations" set with "oauth2", it will override the
value. See https://github.com/ruby-grape/grape-swagger-rails/issues/13.
