### PR TITLE
[ci-skip] Clarify compatible ruby version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,9 @@ language: ruby
 cache: bundler
 
 rvm:
-  - 2.1.2
+  - 2.2.3
+  - 2.1.7
+  - 2.0.0
 
 env:
   - GRAPE_SWAGGER_VERSION=0.8.0


### PR DESCRIPTION
Hi there,

I confirmed ruby 1.9.3 does not work with grape-swagger-rails on this part. 
```erb
# app/views/grape_swagger_rails/application/index.html.erb.

<html data-swagger-options="<%= GrapeSwaggerRails.options.to_h.to_json %>">
```
I know 1.9.3 is not maintained anymore but I think it's still kind to clarify the ruby version if possible . (Yes, I'm still using 1.9.3 in some projects...)
I confirmed 2.0.0 works with rails 3.2 so I added '2.0.0' as the compatible version. (.travis.yml uses 2.1.2, though.)

Let me know if I'm missing something.
Thank you!


