### PR TITLE
Add support for docExpansion option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * Upgraded swagger-ui to v2.1.1 - [@dblock](https://github.com/dblock).
 * Grape-swagger 0.7.2 is no longer supported - [@dblock](https://github.com/dblock).
 * Implemented RuboCop, Ruby-style linter - [@dblock](https://github.com/dblock).
+* [#31](https://github.com/ruby-grape/grape-swagger-rails/pull/31): Support Swagger-UI docExpansion option - [@maruware](https://github.com/maruware).
 * Your contribution here.
 
 ### 0.1.0 (February 5, 2015)

--- a/README.md
+++ b/README.md
@@ -59,6 +59,13 @@ You can specify additional headers to add to each request:
 GrapeSwaggerRails.options.headers['Special-Header'] = 'Some Secret Value'
 ```
 
+You can set docExpansion with "none" or "list" or "full", default is "none".
+See the official Swagger-UI documentation about [SwaggerUi Parameters](https://github.com/swagger-api/swagger-ui#parameters).
+
+```ruby
+GrapeSwaggerRails.options.doc_expansion = 'list'
+```
+
 Using the `headers` option above, you could hard-code Basic Authentication credentials.
 Alternatively, you can configure Basic Authentication through the UI, as described below.
 

--- a/app/views/grape_swagger_rails/application/index.html.erb
+++ b/app/views/grape_swagger_rails/application/index.html.erb
@@ -28,7 +28,7 @@
           console.log(data);
         }
       },
-      docExpansion: "none",
+      docExpansion: options.doc_expansion,
       apisSorter: "alpha"
     });
 

--- a/lib/grape-swagger-rails.rb
+++ b/lib/grape-swagger-rails.rb
@@ -25,6 +25,8 @@ module GrapeSwaggerRails
     api_key_name:         'api_key', # 'Authorization'
     api_key_type:         'query',   # 'header'
 
+    doc_expansion:        'none',
+
     before_filter_proc:   nil # Proc used as a controller before filter
   )
 end

--- a/spec/features/swagger_spec.rb
+++ b/spec/features/swagger_spec.rb
@@ -122,6 +122,34 @@ describe 'Swagger' do
         end
       end
     end
+    context '#doc_expansion' do
+      context 'set list' do
+        before do
+          GrapeSwaggerRails.options.doc_expansion = 'list'
+          visit '/swagger'
+        end
+        it 'sets SwaggerUI docExpansion with list' do
+          expect(page.evaluate_script('window.swaggerUi.options.docExpansion == "list"')).to be true
+        end
+      end
+      context 'set full' do
+        before do
+          GrapeSwaggerRails.options.doc_expansion = 'full'
+          visit '/swagger'
+        end
+        it 'sets SwaggerUI docExpansion with full' do
+          expect(page.evaluate_script('window.swaggerUi.options.docExpansion == "full"')).to be true
+        end
+      end
+      context 'not set' do
+        before do
+          visit '/swagger'
+        end
+        it 'defaults SwaggerUI docExpansion' do
+          expect(page.evaluate_script('window.swaggerUi.options.docExpansion == "none"')).to be true
+        end
+      end
+    end
     after do
       GrapeSwaggerRails.options = @options
     end


### PR DESCRIPTION
This Pull Request will support to use docExpansion option.

```ruby
GrapeSwaggerRails.options.doc_expansion = 'list'
```