### PR TITLE
use Ostruct#marshal_dump instead of #to_h to support Ruby 1.9.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ rvm:
   - 2.2.3
   - 2.1.7
   - 2.0.0
+  - 1.9.3
 
 env:
   - GRAPE_SWAGGER_VERSION=0.8.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Grape-swagger 0.7.2 is no longer supported - [@dblock](https://github.com/dblock).
 * Implemented RuboCop, Ruby-style linter - [@dblock](https://github.com/dblock).
 * [#31](https://github.com/ruby-grape/grape-swagger-rails/pull/31): Support Swagger-UI docExpansion option - [@maruware](https://github.com/maruware).
+* [#32](https://github.com/ruby-grape/grape-swagger-rails/pull/32): Fix Ruby 1.9.3 compatibility - [@suan](https://github.com/suan).
 * Your contribution here.
 
 ### 0.1.0 (February 5, 2015)

--- a/app/views/grape_swagger_rails/application/index.html.erb
+++ b/app/views/grape_swagger_rails/application/index.html.erb
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html data-swagger-options="<%= GrapeSwaggerRails.options.to_h.to_json %>">
+<html data-swagger-options="<%= GrapeSwaggerRails.options.marshal_dump.to_json %>">
 <head>
   <title><%= GrapeSwaggerRails.options.app_name || 'Swagger UI' %></title>
   <link href='//fonts.googleapis.com/css?family=Droid+Sans:400,700' rel='stylesheet' type='text/css'/>


### PR DESCRIPTION
grape-swagger-rails currently breaks on Ruby < 2.0 cause it relies on `OpenStruct#to_h`, which is new. `OpenStruct#marshal_dump` is equivalent and is backwards compatible

Also consider adding v1.9.3 to the Travis matrix?