### PR TITLE
also run 1.9.3 on Travis (to demonstrate failing specs)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ rvm:
   - 2.2.3
   - 2.1.7
   - 2.0.0
+  - 1.9.3
 
 env:
   - GRAPE_SWAGGER_VERSION=0.8.0


### PR DESCRIPTION
Demonstrate that specs fail on Ruby1.9.3 without changes from https://github.com/ruby-grape/grape-swagger-rails/pull/32