### PR TITLE
Headers added before  swaggerUi.load() call.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * [#31](https://github.com/ruby-grape/grape-swagger-rails/pull/31): Support Swagger-UI docExpansion option - [@maruware](https://github.com/maruware).
 * [#32](https://github.com/ruby-grape/grape-swagger-rails/pull/32): Fix Ruby 1.9.3 compatibility - [@suan](https://github.com/suan).
 * [#39](https://github.com/ruby-grape/grape-swagger-rails/pull/39): Support CSS media queries - [@alexagranov](https://github.com/alexagranov).
+* [#42](https://github.com/ruby-grape/grape-swagger-rails/pull/42): Headers added on swaggerUi initialization (before swaggerUi.load() call) - [@sedx](https://github.com/sedx).
 * Your contribution here.
 
 ### 0.1.0 (February 5, 2015)

--- a/app/views/grape_swagger_rails/application/index.html.erb
+++ b/app/views/grape_swagger_rails/application/index.html.erb
@@ -10,11 +10,17 @@
 	$(function () {
 	  var options = $("html").data('swagger-options');
 
+    var headers = {};
+    <% GrapeSwaggerRails.options.headers.each_with_index do |(key, value), index| %>
+      <%=raw "headers.header_#{index} = new SwaggerClient.ApiKeyAuthorization('#{CGI.escapeHTML(key)}', '#{CGI.escapeHTML(value)}', 'header');" %>
+    <% end %>
+
     window.swaggerUi = new SwaggerUi({
       url: options.app_url + options.url,
       dom_id: "swagger-ui-container",
       supportHeaderParams: true,
       supportedSubmitMethods: ['get', 'post', 'put', 'delete', 'patch'],
+      authorizations: headers,
       onComplete: function(swaggerApi, swaggerUi){
         if('console' in window) {
           console.log("Loaded SwaggerUI")
@@ -50,9 +56,6 @@
 
     window.swaggerUi.load();
 
-    <% GrapeSwaggerRails.options.headers.each_with_index do |(key, value), index| %>
-      <%=raw "window.swaggerUi.api.clientAuthorizations.add('header_#{index}', new SwaggerClient.ApiKeyAuthorization('#{CGI.escapeHTML(key)}', '#{CGI.escapeHTML(value)}', 'header'));" %>
-    <% end %>
   });
   </script>
 </head>

--- a/spec/features/swagger_spec.rb
+++ b/spec/features/swagger_spec.rb
@@ -23,6 +23,9 @@ describe 'Swagger' do
         visit '/swagger'
       end
       it 'adds headers' do
+        headers = page.evaluate_script('swaggerUi.api.clientAuthorizations')['authz']
+        expect(headers.select { |key| key.to_s.match(/^header/) }).not_to be_blank
+        expect(headers.fetch('header_0', {}).fetch('name', {})).to eq GrapeSwaggerRails.options.headers.keys.first
         find('#endpointListTogger_headers', visible: true).click
         first('a[href="#!/headers/GET_api_headers_format"]', visible: true).click
         click_button 'Try it out!'


### PR DESCRIPTION
My application use auth by headers content.
When Swagger UI fetch source from swagger documentation path it return 401 because headers sets after call _swaggerUI.load()_ and request for swagger documentation dosen't include auth headers.

In my version headers sets in initialize swaggerUI object and when _swaggerUI.load() _call request for fetch documantation include header