### PR TITLE
Support Swagger-UI validatorUrl option.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ### 0.2.1 (Next)
 
-* Your contribution here.
+* Support Swagger-UI validatorUrl option - [@davidbrewer](https://github.com/davidbrewer).
 
 ### 0.2.0 (February 23, 2016)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ### 0.2.1 (Next)
 
+* Your contribution here.
 * Support Swagger-UI validatorUrl option - [@davidbrewer](https://github.com/davidbrewer).
 
 ### 0.2.0 (February 23, 2016)

--- a/README.md
+++ b/README.md
@@ -74,6 +74,13 @@ See the official Swagger-UI documentation about [SwaggerUi Parameters](https://g
 GrapeSwaggerRails.options.doc_expansion = 'list'
 ```
 
+You can set validatorUrl to your own locally deployed Swagger validator, or disable validation by setting this option to nil.
+This is useful to avoid error messages when running Swagger-UI on a server which is not accessible from outside your network.
+
+```ruby
+GrapeSwaggerRails.options.validator_url = nil
+```
+
 Using the `headers` option above, you could hard-code Basic Authentication credentials.
 Alternatively, you can configure Basic Authentication through the UI, as described below.
 

--- a/app/views/grape_swagger_rails/application/index.html.erb
+++ b/app/views/grape_swagger_rails/application/index.html.erb
@@ -36,6 +36,7 @@
         }
       },
       docExpansion: options.doc_expansion,
+      validatorUrl: options.validator_url,
       apisSorter: "alpha"
     });
 

--- a/spec/features/swagger_spec.rb
+++ b/spec/features/swagger_spec.rb
@@ -153,6 +153,36 @@ describe 'Swagger' do
         end
       end
     end
+    context '#validator_url' do
+      context 'set null' do
+        before do
+          GrapeSwaggerRails.options.validator_url = nil
+          visit '/swagger'
+        end
+        it 'sets SwaggerUI validatorUrl to null' do
+          expect(page.evaluate_script('window.swaggerUi.options.validatorUrl === null && '\
+            'typeof window.swaggerUi.options.validatorUrl === "object"')).to be true
+        end
+      end
+      context 'set a url' do
+        before do
+          GrapeSwaggerRails.options.validator_url = 'http://www.example.com/'
+          visit '/swagger'
+        end
+        it 'sets SwaggerUI validatorUrl to expected url' do
+          expect(page.evaluate_script('window.swaggerUi.options.validatorUrl === "http://www.example.com/"')).to be true
+        end
+      end
+      context 'not set' do
+        before do
+          visit '/swagger'
+        end
+        it 'defaults SwaggerUI validatorUrl' do
+          expect(page.evaluate_script('window.swaggerUi.options.validatorUrl === undefined && '\
+            'typeof window.swaggerUi.options.validatorUrl === "undefined"')).to be true
+        end
+      end
+    end
     after do
       GrapeSwaggerRails.options = @options
     end


### PR DESCRIPTION
When you are running Swagger-UI on a server which is not open to external access, the default validation behavior causes an error message to be displayed. This change allows you to set a validator_url option to nil, which suppresses this error message. You could also point to a validator service under your own control.