### PR TITLE
Fix authorization headers feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ### 0.2.1 (Next)
 
 * Your contribution here.
+* Fixed header-based authorization - [@davidbrewer](https://github.com/davidbrewer).
 * Support Swagger-UI validatorUrl option - [@davidbrewer](https://github.com/davidbrewer).
 
 ### 0.2.0 (February 23, 2016)

--- a/app/views/grape_swagger_rails/application/index.html.erb
+++ b/app/views/grape_swagger_rails/application/index.html.erb
@@ -28,6 +28,7 @@
           console.log(swaggerUi);
         }
         $('pre code').each(function(i, e) {hljs.highlightBlock(e)});
+        addApiKeyAuthorization();
       },
       onFailure: function(data) {
         if('console' in window) {
@@ -40,20 +41,20 @@
       apisSorter: "alpha"
     });
 
-    $('#input_apiKey').change(function() {
+    function addApiKeyAuthorization() {
       var key = $('#input_apiKey')[0].value;
 
-      if(key && key.trim() != "") {
+      if (key && key.trim() != "") {
         if (options.api_auth == 'basic') {
           key = "Basic " + Base64.encode(key);
         } else if (options.api_auth == 'bearer') {
           key = "Bearer " + key
         }
         window.swaggerUi.api.clientAuthorizations.add("key", new SwaggerClient.ApiKeyAuthorization(options.api_key_name, key, options.api_key_type));
-      } else {
-        window.swaggerUi.api.clientAuthorizations.add("key", null);
-      }
-    });
+      } 
+  }
+
+    $('#input_apiKey').change(addApiKeyAuthorization);
 
     window.swaggerUi.load();
 


### PR DESCRIPTION
Hello! I don't believe this is a ready-to-merge PR, but I thought that this would be the best way to start a discussion of it.

In the discussion of PR #25, @supagroova mentioned a change he had made to the index template which fixed some issues with using authorization headers. I found that a variant on this change was necessary to get my own authorization headers working properly, because otherwise the headers just didn't get sent with requests at all.

The change shown in this PR is similar to what I read on PR #25, except that I kept in the code which gets the api_auth, api_key_name and api_key_type from the grape-swagger-rails configuration. It seems to fix the issue for me, without causing any regressions. 

However, I'm unsure how best to write a test that demonstrates that this fixes an issue. I'm also not using this library in an especially complex way so I'm uncertain if I may have broken something that I'm not using myself. Let me know if you have any ideas as to steps I can take to improve this PR to make it something useful for you.