### PR TITLE
escape the GrapeSwaggerRails.options hash properly in the template

### DIFF
--- a/.ruby-gemset
+++ b/.ruby-gemset
@@ -1,0 +1,1 @@
+grape-swagger-rails

--- a/app/views/grape_swagger_rails/application/index.html.erb
+++ b/app/views/grape_swagger_rails/application/index.html.erb
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html data-swagger-options="<%= GrapeSwaggerRails.options.marshal_dump.to_json %>">
+<html data-swagger-options='<%== GrapeSwaggerRails.options.marshal_dump.to_json %>'>
 <head>
   <title><%= GrapeSwaggerRails.options.app_name || 'Swagger UI' %></title>
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/spec/features/swagger_spec.rb
+++ b/spec/features/swagger_spec.rb
@@ -16,6 +16,13 @@ describe 'Swagger' do
     before do
       @options = GrapeSwaggerRails.options.dup
     end
+
+    it 'evaluates config options correctly' do
+      visit '/swagger'
+      page_options_json = page.evaluate_script("$('html').data('swagger-options')").to_json
+      expect(page_options_json).to eq(@options.marshal_dump.to_json)
+    end
+
     context '#headers' do
       before do
         GrapeSwaggerRails.options.headers['X-Test-Header'] = 'Test Value'


### PR DESCRIPTION
The `<%=` erb syntax escapes strings for html purposes, which means that the data attribute was receiving a string filled with `&quot;`s and such. Instead we should use `<%==`. The produced json will contain double-quotes, so the attribute should be set in single quotes.