### PR TITLE
Feature/options supported submit methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ### 0.2.2 (Next)
 
-* Your contribution here
+* [#57](https://github.com/ruby-grape/grape-swagger-rails/pull/57): Support Swagger-UI supportedSubmitMethods option - [@ShadowWrathOogles](https://github.com/ShadowWrathOogles).
 
 ### 0.2.1 (May 21, 2016)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ### 0.2.2 (Next)
 
 * [#57](https://github.com/ruby-grape/grape-swagger-rails/pull/57): Support Swagger-UI supportedSubmitMethods option - [@ShadowWrathOogles](https://github.com/ShadowWrathOogles).
+* Your contribution here.
 
 ### 0.2.1 (May 21, 2016)
 

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ See the official Swagger-UI documentation about [SwaggerUi Parameters](https://g
 GrapeSwaggerRails.options.doc_expansion = 'list'
 ```
 
-You can set supportedSubmitMethods with an array of the supported HTTP methods, default is ["get" "post" "put" "delete" "patch"]
+You can set supportedSubmitMethods with an array of the supported HTTP methods, default is ["get" "post" "put" "delete" "patch"].
 See the official Swagger-UI documentation about [SwaggerUi Parameters](https://github.com/swagger-api/swagger-ui#parameters).
 
 ```ruby

--- a/README.md
+++ b/README.md
@@ -75,7 +75,10 @@ See the official Swagger-UI documentation about [SwaggerUi Parameters](https://g
 GrapeSwaggerRails.options.doc_expansion = 'list'
 ```
 
-You can set supportedSubmitMethods with an array of the supported HTTP methods, default is ["get" "post" "put" "delete" "patch"].
+You can set supportedSubmitMethods with an array of the supported HTTP methods, default is: 
+```ruby
+["get" "post" "put" "delete" "patch"]
+```
 See the official Swagger-UI documentation about [SwaggerUi Parameters](https://github.com/swagger-api/swagger-ui#parameters).
 
 ```ruby

--- a/README.md
+++ b/README.md
@@ -75,6 +75,13 @@ See the official Swagger-UI documentation about [SwaggerUi Parameters](https://g
 GrapeSwaggerRails.options.doc_expansion = 'list'
 ```
 
+You can set supportedSubmitMethods with an array of the supported HTTP methods, default is ["get" "post" "put" "delete" "patch"]
+See the official Swagger-UI documentation about [SwaggerUi Parameters](https://github.com/swagger-api/swagger-ui#parameters).
+
+```ruby
+GrapeSwaggerRails.options.supported_submit_methods = ["get"]
+```
+
 You can set validatorUrl to your own locally deployed Swagger validator, or disable validation by setting this option to nil.
 This is useful to avoid error messages when running Swagger-UI on a server which is not accessible from outside your network.
 

--- a/app/views/grape_swagger_rails/application/index.html.erb
+++ b/app/views/grape_swagger_rails/application/index.html.erb
@@ -19,7 +19,7 @@
       url: options.app_url + options.url,
       dom_id: "swagger-ui-container",
       supportHeaderParams: true,
-      supportedSubmitMethods: options.supported_submit_methods,
+      supportedSubmitMethods: options.supported_submit_methods || [],
       authorizations: headers,
       onComplete: function(swaggerApi, swaggerUi){
         if('console' in window) {

--- a/app/views/grape_swagger_rails/application/index.html.erb
+++ b/app/views/grape_swagger_rails/application/index.html.erb
@@ -19,7 +19,7 @@
       url: options.app_url + options.url,
       dom_id: "swagger-ui-container",
       supportHeaderParams: true,
-      supportedSubmitMethods: ['get', 'post', 'put', 'delete', 'patch'],
+      supportedSubmitMethods: options.supported_submit_methods,
       authorizations: headers,
       onComplete: function(swaggerApi, swaggerUi){
         if('console' in window) {

--- a/lib/grape-swagger-rails.rb
+++ b/lib/grape-swagger-rails.rb
@@ -27,6 +27,7 @@ module GrapeSwaggerRails
     api_key_default_value:  '', # Auto populates api_key
 
     doc_expansion:          'none',
+    supported_submit_methods: %w(get post put delete patch),
 
     before_filter_proc:     nil, # Proc used as a controller before filter
 

--- a/spec/features/swagger_spec.rb
+++ b/spec/features/swagger_spec.rb
@@ -153,6 +153,55 @@ describe 'Swagger' do
         end
       end
     end
+    context '#supported_submit_methods' do
+      context 'set all operations' do
+        before do
+          GrapeSwaggerRails.options.supported_submit_methods = %w(get post put delete patch)
+          visit '/swagger'
+        end
+        it 'sets SwaggerUI supportedSubmitMethods with all operations' do
+          expect(page.evaluate_script('window.swaggerUi.options.supportedSubmitMethods.length')).to eq 5
+          find('#endpointListTogger_params', visible: true).click
+          first('span[class="http_method"] a', visible: true).click
+          expect(page).to have_button('Try it out!', disabled: false)
+        end
+      end
+      context 'set some operations' do
+        before do
+          GrapeSwaggerRails.options.supported_submit_methods = ['post']
+          visit '/swagger'
+        end
+        it 'sets SwaggerUI supportedSubmitMethods with some operations' do
+          expect(page.evaluate_script('window.swaggerUi.options.supportedSubmitMethods.length')).to eq 1
+          find('#endpointListTogger_params', visible: true).click
+          first('span[class="http_method"] a', visible: true).click
+          expect(page).not_to have_button('Try it out!')
+        end
+      end
+      context 'set nil' do
+        before do
+          GrapeSwaggerRails.options.supported_submit_methods = nil
+          visit '/swagger'
+        end
+        it 'clears SwaggerUI supportedSubmitMethods' do
+          expect(page.evaluate_script('window.swaggerUi.options.supportedSubmitMethods.length')).to eq 0
+          find('#endpointListTogger_params', visible: true).click
+          first('span[class="http_method"] a', visible: true).click
+          expect(page).not_to have_button('Try it out!')
+        end
+      end
+      context 'not set' do
+        before do
+          visit '/swagger'
+        end
+        it 'defaults SwaggerUI supportedSubmitMethods' do
+          expect(page.evaluate_script('window.swaggerUi.options.supportedSubmitMethods.length')).to eq 5
+          find('#endpointListTogger_params', visible: true).click
+          first('span[class="http_method"] a', visible: true).click
+          expect(page).to have_button('Try it out!', disabled: false)
+        end
+      end
+    end
     context '#validator_url' do
       context 'set null' do
         before do


### PR DESCRIPTION
Adding in the ability to use the supportedSubmitMethods option to hide the "Try it now!" button on different operations.  Set default to all and assigning nil is treated as an empty list.

Includes updated README and rspec tests.