### PR TITLE
Remove grape and grape-swagger from dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ### 0.2.2 (Next)
 
 * [#57](https://github.com/ruby-grape/grape-swagger-rails/pull/57): Support Swagger-UI supportedSubmitMethods option - [@ShadowWrathOogles](https://github.com/ShadowWrathOogles).
+* [#61](https://github.com/ruby-grape/grape-swagger-rails/pull/61): Removed grape and grape-swagger from required dependencies - [@aschuster3](https://github.com/aschuster3).
 * Your contribution here.
 
 ### 0.2.1 (May 21, 2016)
@@ -8,7 +9,7 @@
 * Fixed header-based authorization - [@davidbrewer](https://github.com/davidbrewer).
 * Support Swagger-UI validatorUrl option - [@davidbrewer](https://github.com/davidbrewer).
 * Support for grape 0.14.x through 0.16.x and grape-swagger 0.11.x through 0.20.x - [@dblock](https://github.com/dblock).
-* [#55](https://github.com/ruby-grape/grape-swagger-rails/pull/55): Update Swagger-UI assets and add ability to hide input boxes - [@aschuster93](https://github.com/aschuster93).
+* [#55](https://github.com/ruby-grape/grape-swagger-rails/pull/55): Update Swagger-UI assets and add ability to hide input boxes - [@aschuster3](https://github.com/aschuster3).
 
 ### 0.2.0 (February 23, 2016)
 

--- a/grape-swagger-rails.gemspec
+++ b/grape-swagger-rails.gemspec
@@ -17,7 +17,6 @@ Gem::Specification.new do |spec|
   spec.require_paths = %w(lib)
 
   spec.add_dependency 'railties', '>= 3.2.12'
-  spec.add_dependency 'grape-swagger', '>= 0.7.2'
 
   spec.add_development_dependency 'bundler', '~> 1.3'
   spec.add_development_dependency 'rake'
@@ -25,6 +24,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rspec-rails'
   spec.add_development_dependency 'capybara'
   spec.add_development_dependency 'grape'
+  spec.add_development_dependency 'grape-swagger', '>= 0.7.2'
   spec.add_development_dependency 'selenium-webdriver'
   spec.add_development_dependency 'sass-rails'
   spec.add_development_dependency 'uglifier'


### PR DESCRIPTION
While this gem was constructed with `grape` and `grape-swagger` in mind, they are technically not necessary for non-test purposes.  This will address [this issue](https://github.com/ruby-grape/grape-swagger-rails/issues/60).