### PR TITLE
Rails 5 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ### 0.2.3 (Next)
 
-* [#XX](https://github.com/ruby-grape/grape-swagger-rails/pull/XX): Rails 5 support - [@serggl](https://github.com/serggl).
+* [#70](https://github.com/ruby-grape/grape-swagger-rails/pull/70): Rails 5 support - [@serggl](https://github.com/serggl).
 * [#68](https://github.com/ruby-grape/grape-swagger-rails/pull/68): Added danger, PR linter - [@dblock](https://github.com/dblock).
 * Your contribution here.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ### 0.2.3 (Next)
 
+* [#XX](https://github.com/ruby-grape/grape-swagger-rails/pull/XX): Rails 5 support - [@serggl](https://github.com/serggl).
 * [#68](https://github.com/ruby-grape/grape-swagger-rails/pull/68): Added danger, PR linter - [@dblock](https://github.com/dblock).
 * Your contribution here.
 

--- a/README.md
+++ b/README.md
@@ -48,10 +48,10 @@ GrapeSwaggerRails.options.url      = '/swagger_doc.json'
 GrapeSwaggerRails.options.app_url  = 'http://swagger.wordnik.com'
 ```
 
-You can dynamically set `app_url` for each request use a `before_filter_proc`:
+You can dynamically set `app_url` for each request use a `before_action_proc`:
 
 ```ruby
-GrapeSwaggerRails.options.before_filter_proc = proc {
+GrapeSwaggerRails.options.before_action_proc = proc {
   GrapeSwaggerRails.options.app_url = request.protocol + request.host_with_port
 }
 ```
@@ -118,7 +118,7 @@ If you will know the Authentication key prior to page load or you wish to set it
 GrapeSwaggerRails.options.api_key_default_value = 'your_default_value'
 ```
 
-To set it based on the `current_user` or other request-based parameters, try using it inside of your `before_filter` (See Swagger UI Authorization)
+To set it based on the `current_user` or other request-based parameters, try using it inside of your `before_action` (See Swagger UI Authorization)
 
 ### API Token Authentication
 
@@ -136,7 +136,7 @@ You may want to authenticate users before displaying the Swagger UI, particularl
 Use the `before` option to inspect the request before Swagger UI:
 
 ```ruby
-GrapeSwaggerRails.options.before_filter do |request|
+GrapeSwaggerRails.options.before_action do |request|
   # 1. Inspect the `request` or access the Swagger UI controller via `self`.
   # 2. Check `current_user` or `can? :access, :api`, etc.
   # 3. Redirect or error in case of failure.
@@ -148,7 +148,7 @@ end
 Add the following code to the initializer (swagger.rb):
 
 ```ruby
-GrapeSwaggerRails.options.before_filter do |request|
+GrapeSwaggerRails.options.before_action do |request|
   GrapeSwaggerRails.options.api_key_default_value = current_user.token.token
 end
 ```

--- a/README.md
+++ b/README.md
@@ -48,12 +48,12 @@ GrapeSwaggerRails.options.url      = '/swagger_doc.json'
 GrapeSwaggerRails.options.app_url  = 'http://swagger.wordnik.com'
 ```
 
-You can dynamically set `app_url` for each request use a `before_action_proc`:
+You can dynamically set `app_url` for each request use a `before_action`:
 
 ```ruby
-GrapeSwaggerRails.options.before_action_proc = proc {
+GrapeSwaggerRails.options.before_action do
   GrapeSwaggerRails.options.app_url = request.protocol + request.host_with_port
-}
+end
 ```
 
 You can set the app name, default is "Swagger".

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,0 +1,10 @@
+Upgrading Grape Swagger Rails
+=============================
+
+### Upgrading to >= 0.2.3
+
+#### Changes to Options
+
+The `GrapeSwaggerRails.options.before_filter` option have been deprecated since 0.2.3.
+
+Please use `GrapeSwaggerRails.options.before_action` instead.

--- a/app/controllers/grape_swagger_rails/application_controller.rb
+++ b/app/controllers/grape_swagger_rails/application_controller.rb
@@ -1,11 +1,20 @@
 module GrapeSwaggerRails
   class ApplicationController < ActionController::Base
-    before_action do
-      callback = [GrapeSwaggerRails.options.before_action, GrapeSwaggerRails.options.before_filter].compact.first
-      instance_exec(request, &callback) if callback
+
+    if Rails::VERSION::MAJOR >= 4
+      before_action { run_before_action }
+    else
+      before_filter { run_before_action }
     end
 
     def index
+    end
+
+    private
+
+    def run_before_action
+      callback = [GrapeSwaggerRails.options.before_action, GrapeSwaggerRails.options.before_filter].compact.first
+      instance_exec(request, &callback) if callback
     end
   end
 end

--- a/app/controllers/grape_swagger_rails/application_controller.rb
+++ b/app/controllers/grape_swagger_rails/application_controller.rb
@@ -1,6 +1,5 @@
 module GrapeSwaggerRails
   class ApplicationController < ActionController::Base
-
     if Rails::VERSION::MAJOR >= 4
       before_action { run_before_action }
     else
@@ -13,8 +12,8 @@ module GrapeSwaggerRails
     private
 
     def run_before_action
-      callback = [GrapeSwaggerRails.options.before_action, GrapeSwaggerRails.options.before_filter].compact.first
-      instance_exec(request, &callback) if callback
+      return unless GrapeSwaggerRails.options.before_action
+      instance_exec(request, &GrapeSwaggerRails.options.before_action)
     end
   end
 end

--- a/app/controllers/grape_swagger_rails/application_controller.rb
+++ b/app/controllers/grape_swagger_rails/application_controller.rb
@@ -1,9 +1,8 @@
 module GrapeSwaggerRails
   class ApplicationController < ActionController::Base
-    before_filter do
-      if GrapeSwaggerRails.options.before_filter
-        instance_exec(request, &GrapeSwaggerRails.options.before_filter)
-      end
+    before_action do
+      callback = [GrapeSwaggerRails.options.before_action, GrapeSwaggerRails.options.before_filter].compact.first
+      instance_exec(request, &callback) if callback
     end
 
     def index

--- a/lib/grape-swagger-rails.rb
+++ b/lib/grape-swagger-rails.rb
@@ -3,7 +3,7 @@ require 'grape-swagger-rails/engine'
 module GrapeSwaggerRails
   class Options < OpenStruct
     def before_filter(&block)
-      ActiveSupport::Deprecation.warn('this option is deprecated and going to be removed soon. ' \
+      ActiveSupport::Deprecation.warn('This option is deprecated and going to be removed in 0.3.0. ' \
                                       'Please use `before_action` instead')
       before_action(&block)
     end

--- a/lib/grape-swagger-rails.rb
+++ b/lib/grape-swagger-rails.rb
@@ -3,9 +3,11 @@ require 'grape-swagger-rails/engine'
 module GrapeSwaggerRails
   class Options < OpenStruct
     def before_filter(&block)
-      ActiveSupport::Deprecation.warn('this option is deprecated and going to be removed soon. Please use `before_action` instead')
+      ActiveSupport::Deprecation.warn('this option is deprecated and going to be removed soon. ' \
+                                      'Please use `before_action` instead')
       before_action(&block)
     end
+
     def before_action(&block)
       if block_given?
         self.before_action_proc = block

--- a/lib/grape-swagger-rails.rb
+++ b/lib/grape-swagger-rails.rb
@@ -3,10 +3,14 @@ require 'grape-swagger-rails/engine'
 module GrapeSwaggerRails
   class Options < OpenStruct
     def before_filter(&block)
+      ActiveSupport::Deprecation.warn('this option is deprecated and going to be removed soon. Please use `before_action` instead')
+      before_action(&block)
+    end
+    def before_action(&block)
       if block_given?
-        self.before_filter_proc = block
+        self.before_action_proc = block
       else
-        before_filter_proc
+        before_action_proc
       end
     end
   end
@@ -29,7 +33,7 @@ module GrapeSwaggerRails
     doc_expansion:          'none',
     supported_submit_methods: %w(get post put delete patch),
 
-    before_filter_proc:     nil, # Proc used as a controller before filter
+    before_action_proc:     nil, # Proc used as a controller before action
 
     hide_url_input:         false,
     hide_api_key_input:     false

--- a/spec/features/swagger_spec.rb
+++ b/spec/features/swagger_spec.rb
@@ -101,7 +101,19 @@ describe 'Swagger' do
     end
     context '#before_filter' do
       before do
-        GrapeSwaggerRails.options.before_filter do |_request|
+        GrapeSwaggerRails.options.before_filter { true }
+      end
+      it 'throws deprecation warning' do
+        allow(ActiveSupport::Deprecation).to receive(:warn)
+
+        visit '/swagger'
+
+        expect(ActiveSupport::Deprecation).to have_received(:warn).with('this option is deprecated and going to be removed soon. Please use `before_action` instead')
+      end
+    end
+    context '#before_action' do
+      before do
+        GrapeSwaggerRails.options.before_action do |_request|
           flash[:error] = 'Unauthorized Access'
           redirect_to '/'
           false

--- a/spec/features/swagger_spec.rb
+++ b/spec/features/swagger_spec.rb
@@ -108,7 +108,8 @@ describe 'Swagger' do
 
         visit '/swagger'
 
-        expect(ActiveSupport::Deprecation).to have_received(:warn).with('this option is deprecated and going to be removed soon. Please use `before_action` instead')
+        expect(ActiveSupport::Deprecation).to have_received(:warn).with('this option is deprecated ' \
+          'and going to be removed soon. Please use `before_action` instead')
       end
     end
     context '#before_action' do

--- a/spec/features/swagger_spec.rb
+++ b/spec/features/swagger_spec.rb
@@ -108,8 +108,8 @@ describe 'Swagger' do
 
         visit '/swagger'
 
-        expect(ActiveSupport::Deprecation).to have_received(:warn).with('this option is deprecated ' \
-          'and going to be removed soon. Please use `before_action` instead')
+        expect(ActiveSupport::Deprecation).to have_received(:warn).with('This option is deprecated ' \
+          'and going to be removed in 0.3.0. Please use `before_action` instead')
       end
     end
     context '#before_action' do

--- a/spec/features/swagger_spec.rb
+++ b/spec/features/swagger_spec.rb
@@ -101,12 +101,10 @@ describe 'Swagger' do
     end
     context '#before_filter' do
       before do
-        GrapeSwaggerRails.options.before_filter { true }
+        allow(ActiveSupport::Deprecation).to receive(:warn)
       end
       it 'throws deprecation warning' do
-        allow(ActiveSupport::Deprecation).to receive(:warn)
-
-        visit '/swagger'
+        GrapeSwaggerRails.options.before_filter { true }
 
         expect(ActiveSupport::Deprecation).to have_received(:warn).with('This option is deprecated ' \
           'and going to be removed in 0.3.0. Please use `before_action` instead')


### PR DESCRIPTION
- replaced `before_filter` usages with `before_action`
- added a deprecation warning to `GrapeSwaggerRails.options.before_filter` option