### PR TITLE
update version references to match semantic versioning properly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-### 0.2.3 (Next)
+### 0.3.0 (Next)
 
 * [#70](https://github.com/ruby-grape/grape-swagger-rails/pull/70): Rails 5 support - [@serggl](https://github.com/serggl).
 * [#68](https://github.com/ruby-grape/grape-swagger-rails/pull/68): Added danger, PR linter - [@dblock](https://github.com/dblock).

--- a/lib/grape-swagger-rails.rb
+++ b/lib/grape-swagger-rails.rb
@@ -3,7 +3,7 @@ require 'grape-swagger-rails/engine'
 module GrapeSwaggerRails
   class Options < OpenStruct
     def before_filter(&block)
-      ActiveSupport::Deprecation.warn('This option is deprecated and going to be removed in 0.3.0. ' \
+      ActiveSupport::Deprecation.warn('This option is deprecated and going to be removed in 1.0.0. ' \
                                       'Please use `before_action` instead')
       before_action(&block)
     end

--- a/spec/features/swagger_spec.rb
+++ b/spec/features/swagger_spec.rb
@@ -107,7 +107,7 @@ describe 'Swagger' do
         GrapeSwaggerRails.options.before_filter { true }
 
         expect(ActiveSupport::Deprecation).to have_received(:warn).with('This option is deprecated ' \
-          'and going to be removed in 0.3.0. Please use `before_action` instead')
+          'and going to be removed in 1.0.0. Please use `before_action` instead')
       end
     end
     context '#before_action' do


### PR DESCRIPTION
This should better match semantic versioning after Rails 5 related changes were merged (#70). 
- Since we deprecated `before_filter` option and it is a public API - we must increment a minor version (http://semver.org/#spec-item-7)
- Also changed a deprecation warning to refer version `1.0.0` when `before_filter` option and its deprecation warning should be removed  (http://semver.org/#spec-item-8)