### PR TITLE
Authorization header issue before initialize `SwaggerUI`

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,3 +3,6 @@ AllCops:
     - vendor/**/*
 
 inherit_from: .rubocop_todo.yml
+
+Documentation:
+  Enabled: false

--- a/app/views/grape_swagger_rails/application/index.html.erb
+++ b/app/views/grape_swagger_rails/application/index.html.erb
@@ -15,6 +15,15 @@
       <%=raw "headers.header_#{index} = new SwaggerClient.ApiKeyAuthorization('#{CGI.escapeHTML(key)}', '#{CGI.escapeHTML(value)}', 'header');" %>
     <% end %>
 
+    // In very next line we are going to initialize `SwaggerUi`. But To initialize `SwaggerUi` we need to have authorization header.
+    // And the inside `onComplete` we are adding `Authorization Header` by calling `addApiKeyAuthorization()`.
+    // So, initialization of `SwaggerUi` fails and triggers `onFaiulre` :p
+
+    // And this resolution is to add header before initialize `SwaggerUI`
+    // Some discussions: https://groups.google.com/forum/#!topic/swagger-swaggersocket/tJ0YHdTnBRk
+    // https://github.com/swagger-api/swagger-ui/issues/1171#issuecomment-100374999
+    <%= raw "headers.header_#{GrapeSwaggerRails.options.headers.count} = new SwaggerClient.ApiKeyAuthorization(options.api_key_name, prepareApiKeyAuthorization(), options.api_key_type);" unless GrapeSwaggerRails.options.headers.keys.include?('Authorization') %>
+
     window.swaggerUi = new SwaggerUi({
       url: options.app_url + options.url,
       dom_id: "swagger-ui-container",
@@ -42,6 +51,12 @@
     });
 
     function addApiKeyAuthorization() {
+      var api_key = $('#input_apiKey')[0].value;
+      if (api_key && api_key.trim() != "")
+        window.swaggerUi.api.clientAuthorizations.add("key", new SwaggerClient.ApiKeyAuthorization(options.api_key_name, prepareApiKeyAuthorization(), options.api_key_type));
+    }
+
+    function prepareApiKeyAuthorization() {
       var key = $('#input_apiKey')[0].value;
 
       if (key && key.trim() != "") {
@@ -50,9 +65,9 @@
         } else if (options.api_auth == 'bearer') {
           key = "Bearer " + key
         }
-        window.swaggerUi.api.clientAuthorizations.add("key", new SwaggerClient.ApiKeyAuthorization(options.api_key_name, key, options.api_key_type));
       }
-  }
+      return key;
+    }
 
     $('#input_apiKey').change(addApiKeyAuthorization);
 

--- a/app/views/grape_swagger_rails/application/index.html.erb
+++ b/app/views/grape_swagger_rails/application/index.html.erb
@@ -15,15 +15,6 @@
       <%=raw "headers.header_#{index} = new SwaggerClient.ApiKeyAuthorization('#{CGI.escapeHTML(key)}', '#{CGI.escapeHTML(value)}', 'header');" %>
     <% end %>
 
-    // In very next line we are going to initialize `SwaggerUi`. But To initialize `SwaggerUi` we need to have authorization header.
-    // And the inside `onComplete` we are adding `Authorization Header` by calling `addApiKeyAuthorization()`.
-    // So, initialization of `SwaggerUi` fails and triggers `onFaiulre` :p
-
-    // And this resolution is to add header before initialize `SwaggerUI`
-    // Some discussions: https://groups.google.com/forum/#!topic/swagger-swaggersocket/tJ0YHdTnBRk
-    // https://github.com/swagger-api/swagger-ui/issues/1171#issuecomment-100374999
-    <%#= raw "headers.header_#{GrapeSwaggerRails.options.headers.count} = new SwaggerClient.ApiKeyAuthorization(options.api_key_name, prepareApiKeyAuthorization(), options.api_key_type);" unless GrapeSwaggerRails.options.headers.keys.include?('Authorization') %>
-
     window.swaggerUi = new SwaggerUi({
       url: options.app_url + options.url,
       dom_id: "swagger-ui-container",
@@ -51,12 +42,6 @@
     });
 
     function addApiKeyAuthorization() {
-      var api_key = $('#input_apiKey')[0].value;
-      if (api_key && api_key.trim() != "")
-        window.swaggerUi.api.clientAuthorizations.add("key", new SwaggerClient.ApiKeyAuthorization(options.api_key_name, prepareApiKeyAuthorization(), options.api_key_type));
-    }
-
-    function prepareApiKeyAuthorization() {
       var key = $('#input_apiKey')[0].value;
 
       if (key && key.trim() != "") {
@@ -65,9 +50,9 @@
         } else if (options.api_auth == 'bearer') {
           key = "Bearer " + key
         }
+        window.swaggerUi.api.clientAuthorizations.add("key", new SwaggerClient.ApiKeyAuthorization(options.api_key_name, key, options.api_key_type));
       }
-      return key;
-    }
+  }
 
     $('#input_apiKey').change(addApiKeyAuthorization);
 

--- a/app/views/grape_swagger_rails/application/index.html.erb
+++ b/app/views/grape_swagger_rails/application/index.html.erb
@@ -22,7 +22,7 @@
     // And this resolution is to add header before initialize `SwaggerUI`
     // Some discussions: https://groups.google.com/forum/#!topic/swagger-swaggersocket/tJ0YHdTnBRk
     // https://github.com/swagger-api/swagger-ui/issues/1171#issuecomment-100374999
-    <%= raw "headers.header_#{GrapeSwaggerRails.options.headers.count} = new SwaggerClient.ApiKeyAuthorization(options.api_key_name, prepareApiKeyAuthorization(), options.api_key_type);" unless GrapeSwaggerRails.options.headers.keys.include?('Authorization') %>
+    <%#= raw "headers.header_#{GrapeSwaggerRails.options.headers.count} = new SwaggerClient.ApiKeyAuthorization(options.api_key_name, prepareApiKeyAuthorization(), options.api_key_type);" unless GrapeSwaggerRails.options.headers.keys.include?('Authorization') %>
 
     window.swaggerUi = new SwaggerUi({
       url: options.app_url + options.url,

--- a/spec/dummy/app/api/api.rb
+++ b/spec/dummy/app/api/api.rb
@@ -26,5 +26,6 @@ class API < Grape::API
     request.params.as_json
   end
 
+  mount V1::Resources::Animals
   add_swagger_documentation
 end

--- a/spec/dummy/app/api/v1/resources/animals.rb
+++ b/spec/dummy/app/api/v1/resources/animals.rb
@@ -1,3 +1,4 @@
+# This is a API endpoint class for animals
 module V1
   module Resources
     class Animals < Grape::API

--- a/spec/dummy/app/api/v1/resources/animals.rb
+++ b/spec/dummy/app/api/v1/resources/animals.rb
@@ -1,0 +1,11 @@
+module V1
+  module Resources
+    class Animals < Grape::API
+      namespace :animals do
+        get do
+          [{ id: 1, name: 'Foo' }]
+        end
+      end
+    end
+  end
+end

--- a/spec/dummy/app/api/v1/resources/animals.rb
+++ b/spec/dummy/app/api/v1/resources/animals.rb
@@ -9,4 +9,4 @@ module V1
       end
     end
   end
-end
+end # this class mounted in '/api.rb'

--- a/spec/dummy/app/api/v1/resources/animals.rb
+++ b/spec/dummy/app/api/v1/resources/animals.rb
@@ -1,4 +1,3 @@
-# This is a API endpoint class for animals
 module V1
   module Resources
     class Animals < Grape::API
@@ -9,4 +8,4 @@ module V1
       end
     end
   end
-end # this class mounted in '/api.rb'
+end


### PR DESCRIPTION
[CORE-826](https://welltravel.atlassian.net/browse/CORE-828)
# Bug Description:

Consider this [code block](https://github.com/ruby-grape/grape-swagger-rails/blob/master/app/views/grape_swagger_rails/application/index.html.erb#L18-L42): 

This code block going to initialize `SwaggerUi`. 
**But** To initialize `SwaggerUi` we need to have authorization header. And the inside `onComplete` we are adding `Authorization Header` by calling `addApiKeyAuthorization()`.

So, initialization of `SwaggerUi` fails and triggers `onFaiulre` :p
And [this resolution](https://github.com/mur-wtag/grape-swagger-rails/blob/dd103c2b40aa92596a355d0c44fe1ce45144d905/app/views/grape_swagger_rails/application/index.html.erb#L25) is to add header before initialize `SwaggerUI`

Some discussions: 
- https://groups.google.com/forum/#!topic/swagger-swaggersocket/tJ0YHdTnBRk
- https://github.com/swagger-api/swagger-ui/issues/1171#issuecomment-100374999
