### PR TITLE
Added the token api_auth type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Your contribution here.
 * [#82](https://github.com/ruby-grape/grape-swagger-rails/pull/82): Fixed api_key_default_value - [@konto-andrzeja](https://github.com/konto-andrzeja).
+* [#84](https://github.com/ruby-grape/grape-swagger-rails/pull/84): Added the token api_auth type - [@Jack12816](https://github.com/Jack12816).
 
 ### 0.3.0 (September 22, 2016)
 

--- a/README.md
+++ b/README.md
@@ -129,6 +129,20 @@ GrapeSwaggerRails.options.api_key_name = 'api_token'
 GrapeSwaggerRails.options.api_key_type = 'query'
 ```
 
+If your application used token authentication passed as a header, like Rails does (`authenticate_or_request_with_http_token`), you can configure Swagger to send the token in this form:
+
+```
+Authorization: Token token="WCZZYjnOQFUYfJIN2ShH1iD24UHo58A6TI"
+```
+
+by specify:
+
+```ruby
+GrapeSwaggerRails.options.api_auth = 'token'
+GrapeSwaggerRails.options.api_key_name = 'Authorization'
+GrapeSwaggerRails.options.api_key_type = 'header'
+```
+
 You can use the ```api_key``` input box to fill in your API token.
 ### Swagger UI Authorization
 

--- a/app/views/grape_swagger_rails/application/index.html.erb
+++ b/app/views/grape_swagger_rails/application/index.html.erb
@@ -53,7 +53,9 @@
         if (options.api_auth == 'basic') {
           key = "Basic " + Base64.encode(key);
         } else if (options.api_auth == 'bearer') {
-          key = "Bearer " + key
+          key = "Bearer " + key;
+        } else if (options.api_auth == 'token') {
+          key = 'Token token="' + key + '"';
         }
         return new SwaggerClient.ApiKeyAuthorization(options.api_key_name, key, options.api_key_type);
       }


### PR DESCRIPTION
Hey guys, first things first: thanks for this great gem! 

It would be quite useful to have a new `token` authentication type,
which follows the Rails convention. So the `Authorization` header
looks like this:

```
Authorization: Token token="WCZZYjnOQFUYfJIN2ShH1iD24UHo58A6TI"
```

This PR allows the usage of this authentication.