### PR TITLE
Added the token api_auth type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Your contribution here.
 * [#82](https://github.com/ruby-grape/grape-swagger-rails/pull/82): Fixed api_key_default_value - [@konto-andrzeja](https://github.com/konto-andrzeja).
+* [#84](https://github.com/ruby-grape/grape-swagger-rails/pull/84): Added the token api_auth type - [@Jack12816](https://github.com/Jack12816).
 
 ### 0.3.0 (September 22, 2016)
 

--- a/README.md
+++ b/README.md
@@ -128,6 +128,20 @@ GrapeSwaggerRails.options.api_key_name = 'api_token'
 GrapeSwaggerRails.options.api_key_type = 'query'
 ```
 
+If your application used token authentication passed as a header, like Rails does (`authenticate_or_request_with_http_token`), you can configure Swagger to send the token in this form:
+
+```
+Authorization: Token token="WCZZYjnOQFUYfJIN2ShH1iD24UHo58A6TI"
+```
+
+by specify:
+
+```ruby
+GrapeSwaggerRails.options.api_auth = 'token'
+GrapeSwaggerRails.options.api_key_name = 'Authorization'
+GrapeSwaggerRails.options.api_key_type = 'header'
+```
+
 You can use the ```api_key``` input box to fill in your API token.
 ### Swagger UI Authorization
 

--- a/app/views/grape_swagger_rails/application/index.html.erb
+++ b/app/views/grape_swagger_rails/application/index.html.erb
@@ -53,7 +53,9 @@
         if (options.api_auth == 'basic') {
           key = "Basic " + Base64.encode(key);
         } else if (options.api_auth == 'bearer') {
-          key = "Bearer " + key
+          key = "Bearer " + key;
+        } else if (options.api_auth == 'token') {
+          key = 'Token token="' + key + '"';
         }
         return new SwaggerClient.ApiKeyAuthorization(options.api_key_name, key, options.api_key_type);
       }

--- a/spec/features/swagger_spec.rb
+++ b/spec/features/swagger_spec.rb
@@ -98,6 +98,23 @@ describe 'Swagger' do
         expect(page).to have_css 'span.hljs-string', text: 'Bearer token'
       end
     end
+    context '#api_auth:token and #api_key_type:header' do
+      before do
+        GrapeSwaggerRails.options.api_auth = 'token'
+        GrapeSwaggerRails.options.api_key_name = 'Authorization'
+        GrapeSwaggerRails.options.api_key_type = 'header'
+        visit '/swagger'
+      end
+      it 'adds an Authorization header' do
+        page.execute_script("$('#input_apiKey').val('token')")
+        page.execute_script("$('#input_apiKey').trigger('change')")
+        find('#endpointListTogger_headers', visible: true).click
+        first('span[class="http_method"] a', visible: true).click
+        click_button 'Try it out!'
+        expect(page).to have_css 'span.hljs-attr', text: 'Authorization'
+        expect(page).to have_css 'span.hljs-string', text: 'Token token'
+      end
+    end
     context '#api_auth:token' do
       before do
         GrapeSwaggerRails.options.api_key_name = 'api_token'


### PR DESCRIPTION
Hey guys, first things first: thanks for this great gem! 

It would be quite useful to have a new `token` authentication type,
which follows the Rails convention. So the `Authorization` header
looks like this:

```
Authorization: Token token="WCZZYjnOQFUYfJIN2ShH1iD24UHo58A6TI"
```

This PR allows the usage of this authentication.