### PR TITLE
Travis: Try to fix build - use Bundler is 1.x, specify exact Firefox version to use

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,16 @@
-sudo: false
-
 addons:
   firefox: "latest"
+
 before_install:
-  - "export DISPLAY=:99.0"
-  - "sh -e /etc/init.d/xvfb start"
-  - wget https://github.com/mozilla/geckodriver/releases/download/v0.16.1/geckodriver-v0.16.1-linux64.tar.gz
+  - wget https://github.com/mozilla/geckodriver/releases/download/v0.20.1/geckodriver-v0.20.1-linux64.tar.gz
   - mkdir geckodriver
-  - tar -xzf geckodriver-v0.16.1-linux64.tar.gz -C geckodriver
+  - tar -xzf geckodriver-v0.20.1-linux64.tar.gz -C geckodriver
   - export PATH=$PATH:$PWD/geckodriver
   - gem install bundler -v'< 2'
+
+before_script:
+  - "export DISPLAY=:99.0"
+  - "sh -e /etc/init.d/xvfb start"
 
 language: ruby
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,10 +20,6 @@ language: ruby
 
 cache: bundler
 
-env:
-  global:
-    - MOZ_HEADLESS=1
-
 matrix:
   include:
     - rvm: 2.3.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ before_install:
   - mkdir geckodriver
   - tar -xzf geckodriver-v0.16.1-linux64.tar.gz -C geckodriver
   - export PATH=$PATH:$PWD/geckodriver
-  - gem install bundler
+  - gem install bundler -v'< 2'
 
 language: ruby
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 addons:
   firefox: "latest"
 
+services:
+  - xvfb
+
 before_install:
   - wget https://github.com/mozilla/geckodriver/releases/download/v0.20.1/geckodriver-v0.20.1-linux64.tar.gz
   - mkdir geckodriver
@@ -11,10 +14,15 @@ before_install:
 before_script:
   - "export DISPLAY=:99.0"
   - "sh -e /etc/init.d/xvfb start"
+  - sleep 3 # give xvfb some time to start
 
 language: ruby
 
 cache: bundler
+
+env:
+  global:
+    - MOZ_HEADLESS=1
 
 matrix:
   include:
@@ -47,4 +55,3 @@ matrix:
     - rvm: ruby-head
     - rvm: jruby-head
     - rvm: rbx-2
-

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,13 @@
 addons:
-  firefox: "latest"
+  firefox: 54.0
 
 services:
   - xvfb
 
 before_install:
-  - wget https://github.com/mozilla/geckodriver/releases/download/v0.20.1/geckodriver-v0.20.1-linux64.tar.gz
+  - wget https://github.com/mozilla/geckodriver/releases/download/v0.18.0/geckodriver-v0.18.0-linux64.tar.gz
   - mkdir geckodriver
-  - tar -xzf geckodriver-v0.20.1-linux64.tar.gz -C geckodriver
+  - tar -xzf geckodriver-v0.18.0-linux64.tar.gz -C geckodriver
   - export PATH=$PATH:$PWD/geckodriver
   - gem install bundler -v'< 2'
 


### PR DESCRIPTION
This CI change is about installing Bundler "before 2.0", so that `BUNDLED_WITH` markers in Gemfile.lock do not stop the build.