### PR TITLE
Add test matrix for multiple Ruby versions & update dependencies

### DIFF
--- a/.github/workflows/danger.yml
+++ b/.github/workflows/danger.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: "2.5.6"
+          ruby-version: "2.7"
           bundler-cache: true
       - name: Run Danger
         run: |

--- a/.github/workflows/danger.yml
+++ b/.github/workflows/danger.yml
@@ -5,6 +5,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:

--- a/.github/workflows/danger.yml
+++ b/.github/workflows/danger.yml
@@ -1,9 +1,5 @@
 name: Danger
-on:
-  push:
-    branches:
-      - master
-  pull_request:
+on: [pull_request]
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,5 @@
 name: Tests
-on:  
+on:
   push:
     branches:
       - master
@@ -12,15 +12,15 @@ jobs:
       fail-fast: false
       matrix:
         grape-swagger:
-          - { version: "0.8.0", experimental: false }
-          - { version: "0.9.0", experimental: false }
-          - { version: "0.11.0", experimental: false }
-          - { version: "0.20.2", experimental: false }
-          - { version: "0.33.0", experimental: false }
+          - { version: "1.6.0", experimental: false }
           - { version: "HEAD", experimental: true }
         ruby:
-          - { version: "2.5.6", experimental: false }
+          - { version: "2.7", experimental: false }
+          - { version: "3.0", experimental: false }
+          - { version: "3.1", experimental: false }
+          - { version: "3.2", experimental: false }
           - { version: "ruby-head", experimental: true }
+          - { version: "jruby-9.4.2", experimental: false }
           - { version: "jruby-head", experimental: true }
     env:
       GRAPE_SWAGGER_VERSION: ${{ matrix.grape-swagger.version }}
@@ -34,10 +34,10 @@ jobs:
       - name: Setup Firefox
         uses: browser-actions/setup-firefox@v1
         with:
-          firefox-version: "54.0"
+          firefox-version: "111.0.1"
       - uses: browser-actions/setup-geckodriver@latest
         with:
-          geckodriver-version: "0.18.0"
-      - uses: GabrielBB/xvfb-action@v1
+          geckodriver-version: "0.32.2"
+      - uses: coactions/setup-xvfb@v1
         with:
           run: bundle exec rake spec

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ### Next Release
 
+* [#107](https://github.com/ruby-grape/grape-swagger-rails/pull/107): Add test matrix for multiple ruby versions - [@duffn](https://github.com/duffn).
 * [#105](https://github.com/ruby-grape/grape-swagger-rails/pull/105): Migrate to GitHub Actions - [@duffn](https://github.com/duffn).
 * [#98](https://github.com/ruby-grape/grape-swagger-rails/pull/98): Fix: test against Rails 6 - [@dblock](https://github.com/dblock).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,29 +6,29 @@
 
 * Your contribution here.
 
-### 0.3.1 (February 16, 2019)
+### 0.3.1 (2019/02/16)
 
 * [#82](https://github.com/ruby-grape/grape-swagger-rails/pull/82): Fixed api_key_default_value - [@konto-andrzeja](https://github.com/konto-andrzeja).
 * [#84](https://github.com/ruby-grape/grape-swagger-rails/pull/84): Added the token api_auth type - [@Jack12816](https://github.com/Jack12816).
 
-### 0.3.0 (September 22, 2016)
+### 0.3.0 (2016/09/22)
 
 * [#70](https://github.com/ruby-grape/grape-swagger-rails/pull/70): Rails 5 support - [@serggl](https://github.com/serggl).
 * [#68](https://github.com/ruby-grape/grape-swagger-rails/pull/68): Added danger, PR linter - [@dblock](https://github.com/dblock).
 
-### 0.2.2 (July 13, 2016)
+### 0.2.2 (2016/07/13)
 
 * [#57](https://github.com/ruby-grape/grape-swagger-rails/pull/57): Support Swagger-UI supportedSubmitMethods option - [@ShadowWrathOogles](https://github.com/ShadowWrathOogles).
 * [#61](https://github.com/ruby-grape/grape-swagger-rails/pull/61): Removed grape and grape-swagger from required dependencies - [@aschuster3](https://github.com/aschuster3).
 
-### 0.2.1 (May 21, 2016)
+### 0.2.1 (2016/05/21)
 
 * Fixed header-based authorization - [@davidbrewer](https://github.com/davidbrewer).
 * Support Swagger-UI validatorUrl option - [@davidbrewer](https://github.com/davidbrewer).
 * Support for grape 0.14.x through 0.16.x and grape-swagger 0.11.x through 0.20.x - [@dblock](https://github.com/dblock).
 * [#55](https://github.com/ruby-grape/grape-swagger-rails/pull/55): Update Swagger-UI assets and add ability to hide input boxes - [@aschuster3](https://github.com/aschuster3).
 
-### 0.2.0 (February 23, 2016)
+### 0.2.0 (2016/02/23)
 
 * [#6](https://github.com/ruby-grape/grape-swagger-rails/pull/6): Fix: support multiple predefined headers - [@Tyr0](https://github.com/tyr0).
 * Upgraded swagger-ui to v2.1.1 - [@dblock](https://github.com/dblock).
@@ -39,11 +39,11 @@
 * [#39](https://github.com/ruby-grape/grape-swagger-rails/pull/39): Support CSS media queries - [@alexagranov](https://github.com/alexagranov).
 * [#42](https://github.com/ruby-grape/grape-swagger-rails/pull/42): Headers added on swaggerUi initialization (before swaggerUi.load() call) - [@sedx](https://github.com/sedx).
 
-### 0.1.0 (February 5, 2015)
+### 0.1.0 (2015/02/05)
 
 * [#41](https://github.com/BrandyMint/grape-swagger-rails/pull/41): Compatibility with grape-swagger 0.8.0 and 0.9.0 - [@dblock](https://github.com/dblock).
 
-### 0.0.10 (September 30, 2014)
+### 0.0.10 (2014/09/30)
 
 * [#33](https://github.com/BrandyMint/grape-swagger-rails/pull/33): Fix: make the dummy app runnable - [@dblock](https://github.com/dblock).
 * [#33](https://github.com/BrandyMint/grape-swagger-rails/pull/33): Fix: headers default to nil - [@dblock](https://github.com/dblock).
@@ -55,24 +55,24 @@
 * [#14](https://github.com/BrandyMint/grape-swagger-rails/pull/14): Added app_name to configure title of the app - [@ghilead](https://github.com/ghilead).
 * [#12](https://github.com/BrandyMint/grape-swagger-rails/pull/12): Fix: SwaggerUI url is combined with appUrl - [@ghilead](https://github.com/ghilead).
 
-### 0.0.8 (February 6, 2014)
+### 0.0.8 (2014/02/06)
 
 * [#11](https://github.com/BrandyMint/grape-swagger-rails/pull/11): Fixed image loading - [@bitboxer](https://github.com/bitboxer).
 
-### 0.0.7 (February 5, 2014)
+### 0.0.7 (2014/02/05)
 
 * [#7](https://github.com/BrandyMint/grape-swagger-rails/pull/7): Updated to Swagger-UI 2.0.3 - [@joelvh](https://github.com/joelvh).
 * [#6](https://github.com/BrandyMint/grape-swagger-rails/pull/6): Added appName and appUrl configuration options - [@swistaczek](https://github.com/swistaczek).
 
-### 0.0.4 (July 16, 2013)
+### 0.0.4 (2013/07/16)
 
 * Configure discoveryUrl from Rails - [@dapi](https://github.com/dapi).
 * Added default support for all HTTP methods  - [@mtavaresOS](https://github.com/mtavaresOS).
 
-### 0.0.3 (May 24, 2013)
+### 0.0.3 (2013/05/24)
 
 * Converted to Rails Engine - [@unloved](https://github.com/unloved).
 
-### 0.0.1 (April 5, 2013)
+### 0.0.1 (2013/04/05)
 
 * Initial public release - [@radanisk](https://github.com/Radanisk).

--- a/Gemfile
+++ b/Gemfile
@@ -2,42 +2,32 @@ source 'https://rubygems.org'
 
 gemspec
 
-case version = ENV['GRAPE_SWAGGER_VERSION'] || '~> 0.9.0'
+case version = ENV['GRAPE_SWAGGER_VERSION'] || '~> 1.6.0'
 when 'HEAD'
   gem 'grape-swagger', github: 'ruby-grape/grape-swagger'
-when '0.8.0'
-  gem 'grape', '0.9.0'
-  gem 'grape-swagger', '0.8.0'
-when '0.9.0'
-  gem 'grape', '0.10.1'
-  gem 'grape-swagger', '0.9.0'
-when '0.11.0'
-  gem 'grape', '0.16.2'
-  gem 'grape-swagger', '0.11.0'
-when '0.20.2'
-  gem 'grape', '0.14.0'
-  gem 'grape-swagger', '0.20.2'
 else
   gem 'grape-swagger', version
+  gem 'grape', '>= 1.3.0'
 end
 
 group :development, :test do
-  gem 'ruby-grape-danger', '~> 0.2.0', require: false
+  gem 'capybara'
+  gem 'coffee-rails'
+  gem 'grape-swagger-ui'
+  gem 'jquery-rails'
+  gem 'mime-types'
+  gem 'nokogiri'
+  gem 'rack', '< 3.0'
+  gem 'rack-cors'
+  gem 'rack-no_animations'
   gem 'rake'
   gem 'rspec-rails'
-  gem 'capybara'
-  gem 'selenium-webdriver'
+  gem 'rubocop', '0.77.0'
+  gem 'ruby-grape-danger', '~> 0.2.0', require: false
   gem 'sass'
   gem 'sass-rails'
-  gem 'uglifier'
-  gem 'coffee-rails'
-  gem 'jquery-rails'
-  gem 'grape-swagger-ui'
+  gem 'selenium-webdriver'
   gem 'sprockets'
-  gem 'rack', '~> 1.6'
-  gem 'rack-cors'
-  gem 'rubocop', '0.77.0'
-  gem 'mime-types', '< 3.0'
-  gem 'rack-no_animations'
-  gem 'nokogiri'
+  gem 'uglifier'
+  gem 'webrick'
 end

--- a/README.md
+++ b/README.md
@@ -8,22 +8,21 @@ Swagger UI as Rails Engine for grape-swagger gem.
 
 # Table of Contents
 
-- [GrapeSwaggerRails](#grapeswaggerrails)
-  - [Installation](#installation)
-  - [Compatibility](#compatibility)
-  - [Usage](#usage)
-    - [Basic Authentication](#basic-authentication)
-    - [Pre-fill Authentication](#pre-fill-authentication)
-    - [API Token Authentication](#api-token-authentication)
-    - [Swagger UI Authorization](#swagger-ui-authorization)
-      - [Integration with DoorKeeper](#integration-with-doorkeeper)
-    - [Hiding the API or Authorization text boxes](#hiding-the-api-or-authorization-text-boxes)
-    - [Updating Swagger UI from Dist](#updating-swagger-ui-from-dist)
-    - [Enabling in a Rails-API Project](#enabling-in-a-rails-api-project)
-    - [Enabling in Rails 6 (Sprokets 5)](#enabling-in-rails-6-sprokets-5)
-  - [Contributors](#contributors)
-  - [Contributing](#contributing)
-  - [License](#license)
+- [Installation](#installation)
+- [Compatibility](#compatibility)
+- [Usage](#usage)
+  - [Basic Authentication](#basic-authentication)
+  - [Pre-fill Authentication](#pre-fill-authentication)
+  - [API Token Authentication](#api-token-authentication)
+  - [Swagger UI Authorization](#swagger-ui-authorization)
+    - [Integration with DoorKeeper](#integration-with-doorkeeper)
+  - [Hiding the API or Authorization text boxes](#hiding-the-api-or-authorization-text-boxes)
+  - [Updating Swagger UI from Dist](#updating-swagger-ui-from-dist)
+  - [Enabling in a Rails-API Project](#enabling-in-a-rails-api-project)
+  - [Enabling in Rails 6 (Sprokets 5)](#enabling-in-rails-6-sprokets-5)
+- [Contributors](#contributors)
+- [Contributing](#contributing)
+- [License](#license)
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,25 @@
 
 Swagger UI as Rails Engine for grape-swagger gem.
 
+# Table of Contents
+
+- [GrapeSwaggerRails](#grapeswaggerrails)
+  - [Installation](#installation)
+  - [Compatibility](#compatibility)
+  - [Usage](#usage)
+    - [Basic Authentication](#basic-authentication)
+    - [Pre-fill Authentication](#pre-fill-authentication)
+    - [API Token Authentication](#api-token-authentication)
+    - [Swagger UI Authorization](#swagger-ui-authorization)
+      - [Integration with DoorKeeper](#integration-with-doorkeeper)
+    - [Hiding the API or Authorization text boxes](#hiding-the-api-or-authorization-text-boxes)
+    - [Updating Swagger UI from Dist](#updating-swagger-ui-from-dist)
+    - [Enabling in a Rails-API Project](#enabling-in-a-rails-api-project)
+    - [Enabling in Rails 6 (Sprokets 5)](#enabling-in-rails-6-sprokets-5)
+  - [Contributors](#contributors)
+  - [Contributing](#contributing)
+  - [License](#license)
+
 ## Installation
 
 Add this line to your application's Gemfile:

--- a/grape-swagger-rails.gemspec
+++ b/grape-swagger-rails.gemspec
@@ -1,5 +1,4 @@
-# coding: utf-8
-lib = File.expand_path('../lib', __FILE__)
+lib = File.expand_path('lib', __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'grape-swagger-rails/version'
 
@@ -14,7 +13,7 @@ Gem::Specification.new do |spec|
   spec.license       = 'MIT'
   spec.files         = `git ls-files`.split($INPUT_RECORD_SEPARATOR)
   spec.test_files    = `git ls-files spec`.split($INPUT_RECORD_SEPARATOR)
-  spec.require_paths = %w(lib)
+  spec.require_paths = %w[lib]
 
-  spec.add_dependency 'railties', '>= 3.2.12'
+  spec.add_dependency 'railties', '>= 6.0.6.1'
 end

--- a/spec/dummy/config/initializers/inflections.rb
+++ b/spec/dummy/config/initializers/inflections.rb
@@ -1,0 +1,3 @@
+ActiveSupport::Inflector.inflections(:en) do |inflect|
+  inflect.acronym 'API'
+end


### PR DESCRIPTION
This adds a test matrix for multiple versions of Ruby and `grape-swagger`.

I've tried to leave as much the same as I could, but some changes were necessary and I've also made a few guesses here:

- Support Ruby 2.7+
- Support `grape-swagger` >= 1.6.0
	- The old matrix had very old versions of the package, the most recent being from June 2019. I can add some more recent versions to the matrix if requested and can see what happens, but am not sure how many different versions we want to support.
- Support `railties` >= 6

## Other notes

- Added inflections initializer for `Failure/Error: mount API => '/'`
- Sorted Gemfile
- Updated `mime-types` for error on Ruby 3 ` SyntaxError: /home/runner/work/grape-swagger-rails/grape-swagger-rails/vendor/bundle/ruby/3.0.0/gems/mime-types-2.99.3/lib/mime/types/logger.rb:26: _1 is reserved for numbered 
parameter`
- Added `webrick` for Ruby 3
- Update `rack` to solve resolution conflicts
- gemspec rubocop formatting
- Update GitHub Actions versions


## TODO

- [x] Branched off of https://github.com/ruby-grape/grape-swagger-rails/pull/105 so get that merged first
- [x] Danger broke because I force pushed? Or because it's a fork? https://github.com/danger/danger/issues/1103 
