### PR TITLE
Ensure that ostruct is loaded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * [#110](https://github.com/ruby-grape/grape-swagger-rails/pull/110): Update dummy app to current rails conventions - [@duffn](https://github.com/duffn).
 * [#112](https://github.com/ruby-grape/grape-swagger-rails/pull/112): Add Rubocop Action & autocorrect violations - [@duffn](https://github.com/duffn).
 * [#114](https://github.com/ruby-grape/grape-swagger-rails/pull/114): Add `api_key_placeholder` option - [@SofiaSousa](https://github.com/SofiaSousa).
+* [#116](https://github.com/ruby-grape/grape-swagger-rails/pull/116): Ensure that ostruct is loaded - [@jrmhaig](https://github.com/jrmhaig).
 
 ### 0.4.0 (2023/03/28)
 

--- a/lib/grape-swagger-rails.rb
+++ b/lib/grape-swagger-rails.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'grape-swagger-rails/engine'
+require 'ostruct'
 
 module GrapeSwaggerRails
   class Options < OpenStruct


### PR DESCRIPTION
Following an upgrade of the `json` gem we are seeing the following error:

```
.../.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/grape-swagger-rails-0.4.0/lib/grape-swagger-rails.rb:4:in `<module:GrapeSwaggerRails>': uninitialized constant GrapeSwaggerRails::OpenStruct (NameError)

  class Options < OpenStruct
```

It turns out that `grape-swagger-rails` depends on `ostruct` being required elsewhere in the app. This was being done for us by `json` and with version 2.7.2 ostruct has become optional. See https://github.com/flori/json/pull/565

One solution is to add `require 'ostruct'` immediately prior to where it is used. This is done in this PR.

Another solution would be to not use OpenStruct as it is now discouraged - see https://docs.ruby-lang.org/en/3.0/OpenStruct.html#class-OpenStruct-label-Caveats