### PR TITLE
Ruby 3.5 compatibility

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,6 +15,10 @@ jobs:
           - { ruby: "3.2", rails: "6.1.7", grape-swagger: "2.1.1" }
           - { ruby: "3.2", rails: "7.2.1", grape-swagger: "1.6.1" }
           - { ruby: "3.2", rails: "7.2.1", grape-swagger: "2.1.1" }
+          - { ruby: "3.3", rails: "6.1.7", grape-swagger: "1.6.1" }
+          - { ruby: "3.3", rails: "6.1.7", grape-swagger: "2.1.1" }
+          - { ruby: "3.3", rails: "7.2.1", grape-swagger: "1.6.1" }
+          - { ruby: "3.3", rails: "7.2.1", grape-swagger: "2.1.1" }
           - { ruby: "jruby-9.4.6", rails: "6.1.7", grape-swagger: "1.6.1" }
           - { ruby: "jruby-9.4.6", rails: "6.1.7", grape-swagger: "2.1.1" }
           - { ruby: "jruby-9.4.6", rails: "7.2.1", grape-swagger: "1.6.1" }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * [#124](https://github.com/ruby-grape/grape-swagger-rails/pull/124): Rails 7 compatibility - [@padde](https://github.com/padde).
 * [#125](https://github.com/ruby-grape/grape-swagger-rails/pull/125): Add rails versions to CI matrix - [@padde](https://github.com/padde).
+* [#126](https://github.com/ruby-grape/grape-swagger-rails/pull/126): Ruby 3.5 compatibility - [@padde](https://github.com/padde).
 * Your contribution here.
 
 ### 0.5.0 (2024/04/06)

--- a/grape-swagger-rails.gemspec
+++ b/grape-swagger-rails.gemspec
@@ -15,6 +15,7 @@ Gem::Specification.new do |spec|
   spec.license       = 'MIT'
   spec.files         = `git ls-files`.split($INPUT_RECORD_SEPARATOR)
   spec.require_paths = %w[lib]
+  spec.add_dependency 'ostruct'
   spec.add_dependency 'railties', '>= 6.0.6.1'
   spec.metadata = {
     'bug_tracker_uri' => 'https://github.com/ruby-grape/grape-swagger-rails/issues',


### PR DESCRIPTION
Fixes #121 

The `ostruct` gem was historically included in the default gems included with Ruby. Starting with Ruby 3.3.5 though, requiring `ostruct` without explicitly adding it as dependency generates the following warning:

    warning: ostruct was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.5.0.
    You can add ostruct to your Gemfile or gemspec to silence this warning.

As of Ruby 3.5, the `ostruct` gem will then no longer be shipped with Ruby so we need to explicitly add it to the dependencies.

### Blockers

- #124
  Fixes CI
- #125
  Updates CI matrix so it will be easier to add Ruby 3.3
  Bumps grape-swagger to 2.1.1 so it runs with the latest grape release again

### TODO

- [x] Add Ruby 3.3 to CI matrix