### PR TITLE
Bump firefox and geckodriver

### DIFF
--- a/.github/workflows/head.yml
+++ b/.github/workflows/head.yml
@@ -29,7 +29,7 @@ jobs:
           firefox-version: "130.0"
       - uses: browser-actions/setup-geckodriver@latest
         with:
-          geckodriver-version: "0.32.2"
+          geckodriver-version: "0.35.0"
       - uses: coactions/setup-xvfb@v1
         with:
           run: bundle exec rake spec

--- a/.github/workflows/head.yml
+++ b/.github/workflows/head.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Setup Firefox
         uses: browser-actions/setup-firefox@v1
         with:
-          firefox-version: "111.0.1"
+          firefox-version: "130.0"
       - uses: browser-actions/setup-geckodriver@latest
         with:
           geckodriver-version: "0.32.2"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,7 +37,7 @@ jobs:
           firefox-version: "130.0"
       - uses: browser-actions/setup-geckodriver@latest
         with:
-          geckodriver-version: "0.32.2"
+          geckodriver-version: "0.35.0"
       - uses: coactions/setup-xvfb@v1
         with:
           run: bundle exec rake spec

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Setup Firefox
         uses: browser-actions/setup-firefox@v1
         with:
-          firefox-version: "111.0.1"
+          firefox-version: "130.0"
       - uses: browser-actions/setup-geckodriver@latest
         with:
           geckodriver-version: "0.32.2"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * [#124](https://github.com/ruby-grape/grape-swagger-rails/pull/124): Rails 7 compatibility - [@padde](https://github.com/padde).
 * [#125](https://github.com/ruby-grape/grape-swagger-rails/pull/125): Add rails versions to CI matrix - [@padde](https://github.com/padde).
+* [#127](https://github.com/ruby-grape/grape-swagger-rails/pull/127): Bump Firefox and geckodriver - [@padde](https://github.com/padde).
 * Your contribution here.
 
 ### 0.5.0 (2024/04/06)


### PR DESCRIPTION
Fixes this warning during spec runs:

```
WARN Selenium [:selenium_manager] The geckodriver version (0.32.2) detected in PATH at /opt/hostedtoolcache/geckodriver/0.32.2/x64/geckodriver might not be compatible with the detected firefox version (130.0); currently, geckodriver 0.35.0 is recommended for firefox 130.*, so it is advised to delete the driver in PATH and retry 
```

### Blockers

- #125
  Updates CI matrix so it will be easier to add Ruby 3.3
  Bumps grape-swagger to 2.1.1 so it runs with the latest grape release again