### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/danger.yml
+++ b/.github/workflows/danger.yml
@@ -4,7 +4,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
       - name: Set up Ruby

--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -4,7 +4,7 @@ jobs:
   rubocop:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v5
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,15 +19,15 @@ jobs:
           - { ruby: "3.3", rails: "6.1.7", grape-swagger: "2.1.1" }
           - { ruby: "3.3", rails: "7.2.1", grape-swagger: "1.6.1" }
           - { ruby: "3.3", rails: "7.2.1", grape-swagger: "2.1.1" }
-          - { ruby: "jruby-9.4.6", rails: "6.1.7", grape-swagger: "1.6.1" }
-          - { ruby: "jruby-9.4.6", rails: "6.1.7", grape-swagger: "2.1.1" }
-          - { ruby: "jruby-9.4.6", rails: "7.2.1", grape-swagger: "1.6.1" }
-          - { ruby: "jruby-9.4.6", rails: "7.2.1", grape-swagger: "2.1.1" }
+          - { ruby: "jruby-9.4", rails: "6.1.7", grape-swagger: "1.6.1" }
+          - { ruby: "jruby-9.4", rails: "6.1.7", grape-swagger: "2.1.1" }
+          - { ruby: "jruby-9.4", rails: "7.2.1", grape-swagger: "1.6.1" }
+          - { ruby: "jruby-9.4", rails: "7.2.1", grape-swagger: "2.1.1" }
     env:
       GRAPE_SWAGGER_VERSION: ${{ matrix.entry.grape-swagger }}
       RAILS_VERSION: ${{ matrix.entry.rails }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v5
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
@@ -42,6 +42,7 @@ jobs:
       - uses: browser-actions/setup-geckodriver@latest
         with:
           geckodriver-version: "0.35.0"
-      - uses: coactions/setup-xvfb@v1
+      - name: Run tests
+        uses: coactions/setup-xvfb@v1
         with:
           run: bundle exec rake spec

--- a/Gemfile
+++ b/Gemfile
@@ -19,6 +19,8 @@ else
   gem 'railties', rails_version
 end
 
+gem 'logger'
+
 group :development, :test do
   gem 'capybara'
   gem 'grape-swagger-ui'

--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'logger'
 require 'bundler/setup'
 require 'bundler/gem_tasks'
 

--- a/lib/tasks/swagger_ui.rake
+++ b/lib/tasks/swagger_ui.rake
@@ -40,9 +40,9 @@ namespace :swagger_ui do
           'swagger-oauth.js',
           'base64.js'
         ].freeze
-        javascript_files = Dir["#{root}/app/assets/javascripts/grape_swagger_rails/*.js"].map { |f|
+        javascript_files = Dir["#{root}/app/assets/javascripts/grape_swagger_rails/*.js"].map do |f|
           f.split('/').last
-        } - ['application.js']
+        end - ['application.js']
         (javascript_files - JAVASCRIPT_FILES).each do |filename|
           puts "WARNING: add #{filename} to swagger_ui.rake"
         end
@@ -65,9 +65,9 @@ namespace :swagger_ui do
           'reset.css',
           'screen.css'
         ].freeze
-        css_files = Dir["#{root}/app/assets/stylesheets/grape_swagger_rails/*.css"].map { |f|
+        css_files = Dir["#{root}/app/assets/stylesheets/grape_swagger_rails/*.css"].map do |f|
           f.split('/').last
-        } - ['application.css']
+        end - ['application.css']
         (css_files - CSS_FILES).each do |filename|
           puts "WARNING: add #{filename} to swagger_ui.rake"
         end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,6 +2,8 @@
 
 ENV['RAILS_ENV'] ||= 'test'
 
+require 'logger'
+
 require File.expand_path('dummy/config/environment.rb', __dir__)
 require 'rspec/rails'
 


### PR DESCRIPTION
CI is broken. This PR fixes it.

There were 2 issues:
- jruby 9.4.6 is no longer available via the setup-ruby action. I changed the version to jruby-9.4 to install the latest 9.4.x version
- [this issue](https://stackoverflow.com/q/79360526) with Rails 6.1. Fixed by adding `require 'logger'` in a couple places.

I only made the minimum changes to get CI to pass again, but I would recommend making the following changes as well:
- drop Ruby 2.7 and 3.0 from the matrix, and add Ruby 3.4
- drop Rails 6.1 from the matrix and add Rails 8.0
- replace `jruby-9.4` with just `jruby` to run the latest stable JRuby

@dblock Let me know if you want me to make any of the above changes, or any other changes.