### PR TITLE
Automatically register assets with Sprockets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
-### 0.6.1 (Next)
+### 0.7.0 (Next)
 
 * Your contribution here.
+* [#132](https://github.com/ruby-grape/grape-swagger-rails/pull/132): Automatically register assets with Sprockets - [@olivier-thatch](https://github.com/olivier-thatch).
 
 ### 0.6.0 (2024/11/21)
 

--- a/Gemfile
+++ b/Gemfile
@@ -35,6 +35,7 @@ group :development, :test do
   gem 'rubocop-rspec'
   gem 'ruby-grape-danger', '~> 0.2.0', require: false
   gem 'selenium-webdriver'
+  gem 'sprockets', ENV.fetch('SPROCKETS_VERSION', '>= 4.0.0')
   gem 'sprockets-rails', require: 'sprockets/railtie'
   gem 'uglifier'
   gem 'webrick'

--- a/README.md
+++ b/README.md
@@ -18,8 +18,6 @@ Swagger UI as Rails Engine for grape-swagger gem.
     - [Integration with DoorKeeper](#integration-with-doorkeeper)
   - [Hiding the API or Authorization text boxes](#hiding-the-api-or-authorization-text-boxes)
   - [Updating Swagger UI from Dist](#updating-swagger-ui-from-dist)
-  - [Enabling in a Rails-API Project](#enabling-in-a-rails-api-project)
-  - [Enabling in Rails 6 (Sprokets 5)](#enabling-in-rails-6-sprokets-5)
 - [Contributors](#contributors)
 - [Contributing](#contributing)
 - [License](#license)
@@ -216,42 +214,6 @@ To update Swagger UI from its [distribution](https://github.com/wordnik/swagger-
 NOTE: This action should be run part of this gem (not your application). In case if you want to
 make it up-to-date, clone the repo, run the rake task, examine the diff, fix any bugs, make sure
 tests pass and then send PR here.
-
-### Enabling in a Rails-API Project
-
-The grape-swagger-rails gem uses the Rails asset pipeline for its Javascript and CSS. Enable the asset pipeline with [rails-api](https://github.com/rails-api/rails-api).
-
-Add sprockets to `config/application.rb`.
-
-```ruby
-require 'sprockets/railtie'
-```
-
-Include JavaScript in `app/assets/javascripts/application.js`.
-
-```javascript
-//
-//= require_tree .
-```
-
-Include CSS stylesheets in `app/assets/stylesheets/application.css`.
-
-```css
-/*
-*= require_tree .
-*/
-```
-
-### Enabling in Rails 6 (Sprokets 5)
-
-Rails 6 top-level targets are determined via `./app/assets/config/manifest.js`. Specify `grape-swagger-rails` asset files as follows.
-
-```javascript
-//= link grape_swagger_rails/application.css
-//= link grape_swagger_rails/application.js
-```
-
-See [Upgrading Sprokets](https://github.com/rails/sprockets/blob/master/UPGRADING.md#manifestjs) for more information.
 
 ## Contributors
 

--- a/lib/grape-swagger-rails/engine.rb
+++ b/lib/grape-swagger-rails/engine.rb
@@ -3,6 +3,21 @@
 module GrapeSwaggerRails
   class Engine < ::Rails::Engine
     paths['lib/tasks'] = 'lib/tasks/exported'
+
     isolate_namespace GrapeSwaggerRails
+
+    initializer 'grape_swagger_rails.assets', group: :all do |app|
+      if app.config.respond_to?(:assets) && defined?(Sprockets)
+        sprockets_4_or_later = Gem::Version.new(Sprockets::VERSION) >= Gem::Version.new('4')
+
+        [
+          'grape_swagger_rails/application.js',
+          'grape_swagger_rails/application.css',
+          'grape_swagger_rails/favicon.ico'
+        ].each do |asset_path|
+          app.config.assets.precompile << (sprockets_4_or_later ? asset_path : proc { |path| path == asset_path })
+        end
+      end
+    end
   end
 end

--- a/lib/grape-swagger-rails/version.rb
+++ b/lib/grape-swagger-rails/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module GrapeSwaggerRails
-  VERSION = '0.6.1'
+  VERSION = '0.7.0'
 end

--- a/spec/dummy/app/assets/config/manifest.js
+++ b/spec/dummy/app/assets/config/manifest.js
@@ -1,3 +1,2 @@
 //= link_directory ../stylesheets .css
 //= link_directory ../javascripts .js
-//= link grape_swagger_rails_manifest.js


### PR DESCRIPTION
Automatically register assets with Sprockets.

This removes the need for users of the gem to add `//= link grape_swagger_rails_manifest.{css,js}` to their own `app/assets/config/manifest.js`.

