### PR TITLE
Migrate Danger to use danger-pr-comment workflow

### DIFF
--- a/.github/workflows/danger-comment.yml
+++ b/.github/workflows/danger-comment.yml
@@ -1,0 +1,9 @@
+name: Danger Comment
+on:
+  workflow_run:
+    workflows: ['Danger']
+    types: [completed]
+jobs:
+  comment:
+    uses: numbata/danger-pr-comment/.github/workflows/danger-comment.yml@v0.1.0
+    secrets: inherit

--- a/.github/workflows/danger.yml
+++ b/.github/workflows/danger.yml
@@ -1,19 +1,11 @@
 name: Danger
-on: [pull_request]
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, edited]
 jobs:
-  lint:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v5
-        with:
-          fetch-depth: 0
-      - name: Set up Ruby
-        uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: "2.7"
-          bundler-cache: true
-      - name: Run Danger
-        run: |
-          # the token is public, has public_repo scope and belongs to the grape-bot user owned by @dblock, this is ok
-          TOKEN=$(echo -n Z2hwX2lYb0dPNXNyejYzOFJyaTV3QUxUdkNiS1dtblFwZTFuRXpmMwo= | base64 --decode)
-          DANGER_GITHUB_API_TOKEN=$TOKEN bundle exec danger --verbose
+  danger:
+    uses: numbata/danger-pr-comment/.github/workflows/danger-run.yml@v0.1.0
+    with:
+      ruby-version: '3.4'
+      bundler-cache: true
+    secrets: inherit

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ### Next Release
 
+* [#138](https://github.com/ruby-grape/grape-swagger-rails/pull/138): Migrate Danger to use danger-pr-comment workflow - [@dblock](https://github.com/dblock).
 * Your contribution here.
 
 ### 0.7.0 (2025/09/16)

--- a/Dangerfile
+++ b/Dangerfile
@@ -1,3 +1,6 @@
 # frozen_string_literal: true
 
-danger.import_dangerfile(gem: 'ruby-grape-danger')
+danger.import_dangerfile(gem: 'danger-pr-comment')
+
+changelog.check!
+toc.check!

--- a/Gemfile
+++ b/Gemfile
@@ -21,6 +21,10 @@ end
 
 group :development, :test do
   gem 'capybara'
+  gem 'danger', require: false
+  gem 'danger-changelog', require: false
+  gem 'danger-pr-comment', require: false
+  gem 'danger-toc', require: false
   gem 'grape-swagger-ui'
   gem 'jquery-rails'
   gem 'mime-types'
@@ -34,7 +38,6 @@ group :development, :test do
   gem 'rubocop-capybara'
   gem 'rubocop-rake'
   gem 'rubocop-rspec'
-  gem 'ruby-grape-danger', '~> 0.2.0', require: false
   gem 'selenium-webdriver'
   gem 'sprockets', ENV.fetch('SPROCKETS_VERSION', '>= 4.0.0'), require: false
   gem 'sprockets-rails', require: false


### PR DESCRIPTION
## Summary
- Migrated from `ruby-grape-danger` to `danger-pr-comment` workflow pattern
- Updated Gemfile to include danger, danger-pr-comment, danger-changelog, and danger-toc gems
- Updated Dangerfile to use changelog.check! and toc.check!
- Created new danger-comment.yml workflow
- Updated danger.yml to use reusable workflows from numbata/danger-pr-comment

Similar to:
- https://github.com/slack-ruby/slack-ruby-client/pull/581
- https://github.com/slack-ruby/slack-ruby-bot-server/pull/181

## Test plan
- [ ] Danger workflow executes successfully
- [ ] Changelog validation works
- [ ] TOC validation works
- [ ] PR comments are posted correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)