### PR TITLE
Add swagger_ui_config pass-through to SwaggerUIBundle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * [#140](https://github.com/ruby-grape/grape-swagger-rails/pull/140): Update CI matrix and compatibility documentation - [@moskvin](https://github.com/moskvin).
 * [#141](https://github.com/ruby-grape/grape-swagger-rails/pull/141): Replace swagger ui 2.x with swaggeruibundle v5 standalone integration - [@moskvin](https://github.com/moskvin).
 * [#142](https://github.com/ruby-grape/grape-swagger-rails/pull/142): Convert view to haml and extract javascript to typescript - [@moskvin](https://github.com/moskvin).
+* [#143](https://github.com/ruby-grape/grape-swagger-rails/pull/143): Add swagger_ui_config pass-through to swaggeruibundle - [@moskvin](https://github.com/moskvin).
 * Your contribution here.
 
 ### 0.7.0 (2025/09/16)

--- a/README.md
+++ b/README.md
@@ -76,6 +76,17 @@ GrapeSwaggerRails.options.url      = '/swagger_doc.json'
 GrapeSwaggerRails.options.app_url  = 'http://swagger.wordnik.com'
 ```
 
+To pass native Swagger UI configuration options through to `SwaggerUIBundle`, use `swagger_ui_config`:
+
+```ruby
+GrapeSwaggerRails.options.swagger_ui_config = {
+  defaultModelsExpandDepth: -1,
+  displayRequestDuration: true
+}
+```
+
+These values are merged into the `SwaggerUIBundle(...)` call before the gem's own defaults, so they apply as base configuration. The gem's own options (such as `url`, `requestInterceptor`, `presets`) still take precedence.
+
 You can dynamically set `app_url` for each request use a `before_action`:
 
 ```ruby

--- a/app/assets/javascripts/grape_swagger_rails/index.js
+++ b/app/assets/javascripts/grape_swagger_rails/index.js
@@ -63,7 +63,7 @@ function initializeSwaggerPage() {
         });
     }
     var specUrl = options.app_url ? options.app_url + options.url : options.url;
-    window.ui = SwaggerUIBundle({
+    window.ui = SwaggerUIBundle(Object.assign({}, options.swagger_ui_config || {}, {
         url: specUrl,
         dom_id: "#swagger-ui-container",
         deepLinking: true,
@@ -93,7 +93,7 @@ function initializeSwaggerPage() {
             setRequestHeader(request, options.api_key_name, apiKeyValue);
             return request;
         },
-    });
+    }));
 }
 if (document.readyState === "loading") {
     document.addEventListener("DOMContentLoaded", initializeSwaggerPage);

--- a/frontend/grape_swagger_rails/index.ts
+++ b/frontend/grape_swagger_rails/index.ts
@@ -18,6 +18,7 @@ interface SwaggerPageOptions {
   theme: string;
   url: string;
   validator_url: string | null | undefined;
+  swagger_ui_config?: Record<string, unknown>;
 }
 
 interface SwaggerRequest {
@@ -115,7 +116,7 @@ function initializeSwaggerPage(): void {
 
   const specUrl = options.app_url ? options.app_url + options.url : options.url;
 
-  window.ui = SwaggerUIBundle({
+  window.ui = SwaggerUIBundle(Object.assign({}, options.swagger_ui_config || {}, {
     url: specUrl,
     dom_id: "#swagger-ui-container",
     deepLinking: true,
@@ -148,7 +149,7 @@ function initializeSwaggerPage(): void {
       setRequestHeader(request, options.api_key_name, apiKeyValue);
       return request;
     },
-  });
+  }));
 }
 
 if (document.readyState === "loading") {

--- a/lib/grape-swagger-rails.rb
+++ b/lib/grape-swagger-rails.rb
@@ -27,6 +27,7 @@ module GrapeSwaggerRails
 
   self.options = Options.new(
     url: '/swagger_doc',
+    swagger_ui_config: {},
     app_name: 'Swagger',
     app_url: '',
 

--- a/spec/features/swagger_spec.rb
+++ b/spec/features/swagger_spec.rb
@@ -294,7 +294,7 @@ describe 'Swagger' do
         configs = swagger_configs
 
         expect(configs.fetch('defaultModelsExpandDepth')).to eq(-1)
-        expect(configs.fetch('displayRequestDuration')).to eq(true)
+        expect(configs.fetch('displayRequestDuration')).to be(true)
       end
     end
 

--- a/spec/features/swagger_spec.rb
+++ b/spec/features/swagger_spec.rb
@@ -281,6 +281,23 @@ describe 'Swagger' do
       end
     end
 
+    describe '#swagger_ui_config' do
+      before do
+        GrapeSwaggerRails.options.swagger_ui_config = {
+          'defaultModelsExpandDepth' => -1,
+          'displayRequestDuration' => true
+        }
+        visit_swagger
+      end
+
+      it 'passes native Swagger UI config through to the bundle' do
+        configs = swagger_configs
+
+        expect(configs.fetch('defaultModelsExpandDepth')).to eq(-1)
+        expect(configs.fetch('displayRequestDuration')).to eq(true)
+      end
+    end
+
     describe '#api_key_default_value' do
       before do
         GrapeSwaggerRails.options.api_auth = 'bearer'


### PR DESCRIPTION
Allows host apps to set any native Swagger UI configuration option via `GrapeSwaggerRails.options.swagger_ui_config`. Values are merged before the gem's own defaults so built-in options (url, requestInterceptor, presets) always take precedence.