### PR TITLE
Add support for multiple API specifications in Swagger UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * [#141](https://github.com/ruby-grape/grape-swagger-rails/pull/141): Replace swagger ui 2.x with swaggeruibundle v5 standalone integration - [@moskvin](https://github.com/moskvin).
 * [#142](https://github.com/ruby-grape/grape-swagger-rails/pull/142): Convert view to haml and extract javascript to typescript - [@moskvin](https://github.com/moskvin).
 * [#143](https://github.com/ruby-grape/grape-swagger-rails/pull/143): Add swagger_ui_config pass-through to swaggeruibundle - [@moskvin](https://github.com/moskvin).
+* [#144](https://github.com/ruby-grape/grape-swagger-rails/pull/144): Add support for multiple api specifications in swagger ui - [@moskvin](https://github.com/moskvin).
 * Your contribution here.
 
 ### 0.7.0 (2025/09/16)

--- a/README.md
+++ b/README.md
@@ -76,6 +76,19 @@ GrapeSwaggerRails.options.url      = '/swagger_doc.json'
 GrapeSwaggerRails.options.app_url  = 'http://swagger.wordnik.com'
 ```
 
+To expose multiple API specifications in the UI, set `urls` instead of a single `url`:
+
+```ruby
+GrapeSwaggerRails.options.urls = [
+  { name: 'v1', url: '/api/v1/swagger_doc' },
+  { name: 'v2', url: '/api/v2/swagger_doc' }
+]
+GrapeSwaggerRails.options.urls_primary_name = 'v2'
+GrapeSwaggerRails.options.app_url = 'http://localhost:3000'
+```
+
+When multiple specs are configured, a spec selector dropdown appears in the Swagger UI header. `urls_primary_name` controls which spec is selected by default.
+
 To pass native Swagger UI configuration options through to `SwaggerUIBundle`, use `swagger_ui_config`:
 
 ```ruby

--- a/app/assets/javascripts/grape_swagger_rails/index.js
+++ b/app/assets/javascripts/grape_swagger_rails/index.js
@@ -8,6 +8,8 @@ function initializeSwaggerPage() {
     }
     var options = JSON.parse(optionsElement);
     var authInput = document.getElementById("input_apiKey");
+    var specSelector = document.getElementById("spec-selector");
+    var specSelectorWrapper = document.getElementById("spec-selector-wrapper");
     var themeToggle = document.getElementById("theme-toggle");
     var root = document.documentElement;
     function getTheme() {
@@ -55,6 +57,67 @@ function initializeSwaggerPage() {
         }
         headers[key] = value;
     }
+    function absoluteSpecUrl(url) {
+        if (!url) {
+            return "";
+        }
+        if (/^https?:\/\//.test(url)) {
+            return url;
+        }
+        return options.app_url + url;
+    }
+    function normalizeSwaggerUrls() {
+        if (!Array.isArray(options.urls)) {
+            return [];
+        }
+        return options.urls
+            .map(function (entry, index) {
+            if (typeof entry === "string") {
+                return { name: entry, url: absoluteSpecUrl(entry) };
+            }
+            return {
+                name: entry.name || entry.url || "Spec " + (index + 1),
+                url: absoluteSpecUrl(entry.url),
+            };
+        })
+            .filter(function (entry) { return Boolean(entry.url); });
+    }
+    function selectedSwaggerUrl(urls) {
+        if (!urls.length) {
+            return null;
+        }
+        if (options.urls_primary_name) {
+            for (var i = 0; i < urls.length; i += 1) {
+                if (urls[i].name === options.urls_primary_name) {
+                    return urls[i];
+                }
+            }
+        }
+        if (options.url) {
+            var absoluteUrl = absoluteSpecUrl(options.url);
+            for (var j = 0; j < urls.length; j += 1) {
+                if (urls[j].url === absoluteUrl) {
+                    return urls[j];
+                }
+            }
+        }
+        return urls[0];
+    }
+    function setupSpecSelector(urls, selectedUrl) {
+        if (!specSelector || !specSelectorWrapper || urls.length < 2) {
+            return;
+        }
+        urls.forEach(function (entry) {
+            var option = document.createElement("option");
+            option.value = entry.url;
+            option.textContent = entry.name;
+            if (selectedUrl && entry.url === selectedUrl.url) {
+                option.selected = true;
+            }
+            specSelector.appendChild(option);
+        });
+        specSelectorWrapper.hidden = false;
+    }
     applyTheme(getTheme());
     if (themeToggle) {
         themeToggle.addEventListener("click", function () {
@@ -62,9 +125,9 @@ function initializeSwaggerPage() {
             applyTheme(options.theme);
         });
     }
-    var specUrl = options.app_url ? options.app_url + options.url : options.url;
-    window.ui = SwaggerUIBundle(Object.assign({}, options.swagger_ui_config || {}, {
-        url: specUrl,
+    var swaggerUrls = normalizeSwaggerUrls();
+    var selectedUrl = selectedSwaggerUrl(swaggerUrls);
+    var bundleConfig = Object.assign({}, options.swagger_ui_config || {}, {
         dom_id: "#swagger-ui-container",
         deepLinking: true,
         docExpansion: options.doc_expansion,
@@ -93,7 +156,26 @@ function initializeSwaggerPage() {
             setRequestHeader(request, options.api_key_name, apiKeyValue);
             return request;
         },
-    }));
+    });
+    if (swaggerUrls.length) {
+        bundleConfig.urls = swaggerUrls;
+        if (selectedUrl) {
+            bundleConfig["urls.primaryName"] = selectedUrl.name;
+        }
+    }
+    else {
+        bundleConfig.url = absoluteSpecUrl(options.url);
+    }
+    window.ui = SwaggerUIBundle(bundleConfig);
+    setupSpecSelector(swaggerUrls, selectedUrl);
+    if (specSelector && swaggerUrls.length > 1) {
+        specSelector.addEventListener("change", function (event) {
+            var target = event.target;
+            var url = target.value;
+            window.ui.specActions.updateUrl(url);
+            window.ui.specActions.download(url);
+        });
+    }
 }
 if (document.readyState === "loading") {
     document.addEventListener("DOMContentLoaded", initializeSwaggerPage);

--- a/app/views/grape_swagger_rails/application/index.html.haml
+++ b/app/views/grape_swagger_rails/application/index.html.haml
@@ -11,6 +11,8 @@
       %a.swagger-brand{ href: GrapeSwaggerRails.options.app_url }= GrapeSwaggerRails.options.app_name
       .swagger-controls
         %button#theme-toggle.swagger-theme-toggle{ type: 'button', aria: { pressed: 'false' } } Dark Mode
+        %label#spec-selector-wrapper.swagger-auth{ hidden: true }
+          %select#spec-selector.swagger-select{ name: 'spec-selector' }
         %label.swagger-auth
           %span.swagger-label= GrapeSwaggerRails.options.api_key_placeholder
           %input#input_apiKey.swagger-input{ name: 'apiKey', type: 'text', value: GrapeSwaggerRails.options.api_key_default_value, placeholder: GrapeSwaggerRails.options.api_key_placeholder }

--- a/frontend/grape_swagger_rails/index.ts
+++ b/frontend/grape_swagger_rails/index.ts
@@ -17,8 +17,20 @@ interface SwaggerPageOptions {
   supported_submit_methods: string[];
   theme: string;
   url: string;
+  urls: Array<string | SwaggerUrlOption> | null;
+  urls_primary_name: string;
   validator_url: string | null | undefined;
   swagger_ui_config?: Record<string, unknown>;
+}
+
+interface SwaggerUrlOption {
+  name?: string;
+  url: string;
+}
+
+interface NormalizedSwaggerUrl {
+  name: string;
+  url: string;
 }
 
 interface SwaggerRequest {
@@ -41,6 +53,8 @@ function initializeSwaggerPage(): void {
 
   const options: SwaggerPageOptions = JSON.parse(optionsElement);
   const authInput = document.getElementById("input_apiKey") as HTMLInputElement | null;
+  const specSelector = document.getElementById("spec-selector") as HTMLSelectElement | null;
+  const specSelectorWrapper = document.getElementById("spec-selector-wrapper") as HTMLLabelElement | null;
   const themeToggle = document.getElementById("theme-toggle") as HTMLButtonElement | null;
   const root = document.documentElement;
 
@@ -105,6 +119,83 @@ function initializeSwaggerPage(): void {
     (headers as Record<string, string>)[key] = value;
   }
 
+  function absoluteSpecUrl(url: string): string {
+    if (!url) {
+      return "";
+    }
+
+    if (/^https?:\/\//.test(url)) {
+      return url;
+    }
+
+    return options.app_url + url;
+  }
+
+  function normalizeSwaggerUrls(): NormalizedSwaggerUrl[] {
+    if (!Array.isArray(options.urls)) {
+      return [];
+    }
+
+    return options.urls
+      .map((entry, index): NormalizedSwaggerUrl => {
+        if (typeof entry === "string") {
+          return { name: entry, url: absoluteSpecUrl(entry) };
+        }
+
+        return {
+          name: entry.name || entry.url || "Spec " + (index + 1),
+          url: absoluteSpecUrl(entry.url),
+        };
+      })
+      .filter((entry) => Boolean(entry.url));
+  }
+
+  function selectedSwaggerUrl(urls: NormalizedSwaggerUrl[]): NormalizedSwaggerUrl | null {
+    if (!urls.length) {
+      return null;
+    }
+
+    if (options.urls_primary_name) {
+      for (let i = 0; i < urls.length; i += 1) {
+        if (urls[i].name === options.urls_primary_name) {
+          return urls[i];
+        }
+      }
+    }
+
+    if (options.url) {
+      const absoluteUrl = absoluteSpecUrl(options.url);
+
+      for (let j = 0; j < urls.length; j += 1) {
+        if (urls[j].url === absoluteUrl) {
+          return urls[j];
+        }
+      }
+    }
+
+    return urls[0];
+  }
+
+  function setupSpecSelector(urls: NormalizedSwaggerUrl[], selectedUrl: NormalizedSwaggerUrl | null): void {
+    if (!specSelector || !specSelectorWrapper || urls.length < 2) {
+      return;
+    }
+
+    urls.forEach((entry) => {
+      const option = document.createElement("option");
+      option.value = entry.url;
+      option.textContent = entry.name;
+
+      if (selectedUrl && entry.url === selectedUrl.url) {
+        option.selected = true;
+      }
+
+      specSelector.appendChild(option);
+    });
+
+    specSelectorWrapper.hidden = false;
+  }
+
   applyTheme(getTheme());
 
   if (themeToggle) {
@@ -114,10 +205,10 @@ function initializeSwaggerPage(): void {
     });
   }
 
-  const specUrl = options.app_url ? options.app_url + options.url : options.url;
+  const swaggerUrls = normalizeSwaggerUrls();
+  const selectedUrl = selectedSwaggerUrl(swaggerUrls);
 
-  window.ui = SwaggerUIBundle(Object.assign({}, options.swagger_ui_config || {}, {
-    url: specUrl,
+  const bundleConfig = Object.assign({}, options.swagger_ui_config || {}, {
     dom_id: "#swagger-ui-container",
     deepLinking: true,
     docExpansion: options.doc_expansion,
@@ -149,7 +240,30 @@ function initializeSwaggerPage(): void {
       setRequestHeader(request, options.api_key_name, apiKeyValue);
       return request;
     },
-  }));
+  });
+
+  if (swaggerUrls.length) {
+    bundleConfig.urls = swaggerUrls;
+
+    if (selectedUrl) {
+      bundleConfig["urls.primaryName"] = selectedUrl.name;
+    }
+  } else {
+    bundleConfig.url = absoluteSpecUrl(options.url);
+  }
+
+  window.ui = SwaggerUIBundle(bundleConfig);
+
+  setupSpecSelector(swaggerUrls, selectedUrl);
+
+  if (specSelector && swaggerUrls.length > 1) {
+    specSelector.addEventListener("change", (event) => {
+      const target = event.target as HTMLSelectElement;
+      const url = target.value;
+      window.ui.specActions.updateUrl(url);
+      window.ui.specActions.download(url);
+    });
+  }
 }
 
 if (document.readyState === "loading") {

--- a/lib/grape-swagger-rails.rb
+++ b/lib/grape-swagger-rails.rb
@@ -27,6 +27,8 @@ module GrapeSwaggerRails
 
   self.options = Options.new(
     url: '/swagger_doc',
+    urls: nil,
+    urls_primary_name: '',
     swagger_ui_config: {},
     app_name: 'Swagger',
     app_url: '',

--- a/spec/dummy/app/api/api.rb
+++ b/spec/dummy/app/api/api.rb
@@ -76,3 +76,15 @@ class API < Grape::API
 
   add_swagger_documentation
 end
+
+class APIv2 < Grape::API
+  prefix 'api'
+  version 'v2', using: :path
+
+  desc 'Get API v2 status.'
+  get '/status' do
+    { version: 'v2', status: 'ok' }
+  end
+
+  add_swagger_documentation
+end

--- a/spec/dummy/config/routes.rb
+++ b/spec/dummy/config/routes.rb
@@ -4,5 +4,6 @@ Rails.application.routes.draw do
   get 'up' => 'rails/health#show', as: :rails_health_check
   root 'welcome#index'
   mount API => '/'
+  mount APIv2 => '/'
   mount GrapeSwaggerRails::Engine => '/swagger'
 end

--- a/spec/features/swagger_spec.rb
+++ b/spec/features/swagger_spec.rb
@@ -281,6 +281,33 @@ describe 'Swagger' do
       end
     end
 
+    describe '#urls' do
+      before do
+        GrapeSwaggerRails.options.urls = [
+          { name: 'v1', url: '/api/swagger_doc' },
+          { name: 'v2', url: '/api/v2/swagger_doc' }
+        ]
+        GrapeSwaggerRails.options.urls_primary_name = 'v2'
+        GrapeSwaggerRails.options.url = '/api/swagger_doc'
+        visit_swagger
+      end
+
+      it 'passes multiple spec URLs to Swagger UI' do
+        configs = swagger_configs
+
+        expect(configs.fetch('urls')).to eq(
+          [
+            { 'name' => 'v1', 'url' => 'http://localhost:3000/api/swagger_doc' },
+            { 'name' => 'v2', 'url' => 'http://localhost:3000/api/v2/swagger_doc' }
+          ]
+        )
+      end
+
+      it 'shows a selector for multiple specs' do
+        expect(page).to have_select('spec-selector', selected: 'v2', options: %w[v1 v2])
+      end
+    end
+
     describe '#swagger_ui_config' do
       before do
         GrapeSwaggerRails.options.swagger_ui_config = {

--- a/spec/features/swagger_spec.rb
+++ b/spec/features/swagger_spec.rb
@@ -303,8 +303,18 @@ describe 'Swagger' do
         )
       end
 
-      it 'shows a selector for multiple specs' do
+      it 'shows a selector with v2 selected by default' do
         expect(page).to have_select('spec-selector', selected: 'v2', options: %w[v1 v2])
+      end
+
+      it 'switches specs via the dropdown without errors' do
+        expect(page).to have_select('spec-selector', selected: 'v2')
+
+        select 'v1', from: 'spec-selector'
+
+        # v1 exposes foos namespace; wait for it to appear in the rendered spec
+        expect(page).to have_css('.opblock-tag', text: 'foos', wait: 10)
+        expect(page).to have_no_css('.errors-wrapper')
       end
     end
 

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -6,3 +6,4 @@ require 'capybara/rails'
 Capybara.default_driver = :selenium
 Capybara.server_port = 3000
 Capybara.server = :webrick
+Capybara.app_host = 'http://localhost'

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -6,4 +6,4 @@ require 'capybara/rails'
 Capybara.default_driver = :selenium
 Capybara.server_port = 3000
 Capybara.server = :webrick
-Capybara.app_host = 'http://localhost'
+Capybara.app_host = "http://localhost:#{Capybara.server_port}"


### PR DESCRIPTION
Adds `urls` and `urls_primary_name` options so a single Swagger UI instance can expose multiple API specifications via a dropdown selector in the header. 