### PR TITLE
Consolidate UI visibility flags into display options hash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * [#142](https://github.com/ruby-grape/grape-swagger-rails/pull/142): Convert view to haml and extract javascript to typescript - [@moskvin](https://github.com/moskvin).
 * [#143](https://github.com/ruby-grape/grape-swagger-rails/pull/143): Add swagger_ui_config pass-through to swaggeruibundle - [@moskvin](https://github.com/moskvin).
 * [#144](https://github.com/ruby-grape/grape-swagger-rails/pull/144): Add support for multiple api specifications in swagger ui - [@moskvin](https://github.com/moskvin).
+* [#146](https://github.com/ruby-grape/grape-swagger-rails/pull/146): Hide swagger ui source url - [@moskvin](https://github.com/moskvin).
 * Your contribution here.
 
 ### 0.7.0 (2025/09/16)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 * [#142](https://github.com/ruby-grape/grape-swagger-rails/pull/142): Convert view to haml and extract javascript to typescript - [@moskvin](https://github.com/moskvin).
 * [#143](https://github.com/ruby-grape/grape-swagger-rails/pull/143): Add swagger_ui_config pass-through to swaggeruibundle - [@moskvin](https://github.com/moskvin).
 * [#144](https://github.com/ruby-grape/grape-swagger-rails/pull/144): Add support for multiple api specifications in swagger ui - [@moskvin](https://github.com/moskvin).
-* [#146](https://github.com/ruby-grape/grape-swagger-rails/pull/146): Hide swagger ui source url - [@moskvin](https://github.com/moskvin).
+* [#146](https://github.com/ruby-grape/grape-swagger-rails/pull/146): Consolidate UI visibility flags into display options hash - [@moskvin](https://github.com/moskvin).
 * Your contribution here.
 
 ### 0.7.0 (2025/09/16)

--- a/Gemfile
+++ b/Gemfile
@@ -5,8 +5,6 @@ source 'https://rubygems.org'
 gemspec
 
 case grape_version = ENV.fetch('GRAPE_VERSION', '~> 2.2.0')
-when nil, ''
-  gem 'grape', '>= 1.3.0'
 when 'HEAD'
   gem 'grape', github: 'ruby-grape/grape'
 else
@@ -20,7 +18,7 @@ else
   gem 'grape-swagger', grape_swagger_version
 end
 
-case rails_version = ENV.fetch('RAILS_VERSION', '>= 6.0.6.1')
+case rails_version = ENV.fetch('RAILS_VERSION', '>= 7.2.3.1')
 when 'edge'
   gem 'railties', github: 'rails/rails', branch: 'main'
 else

--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ source 'https://rubygems.org'
 
 gemspec
 
-case grape_version = ENV.fetch('GRAPE_VERSION', nil)
+case grape_version = ENV.fetch('GRAPE_VERSION', '~> 2.2.0')
 when nil, ''
   gem 'grape', '>= 1.3.0'
 when 'HEAD'
@@ -13,7 +13,7 @@ else
   gem 'grape', grape_version
 end
 
-case grape_swagger_version = ENV.fetch('GRAPE_SWAGGER_VERSION', '~> 1.6.0')
+case grape_swagger_version = ENV.fetch('GRAPE_SWAGGER_VERSION', '~> 2.1.3')
 when 'HEAD'
   gem 'grape-swagger', github: 'ruby-grape/grape-swagger'
 else

--- a/README.md
+++ b/README.md
@@ -263,7 +263,7 @@ has_one :token, -> { order 'created_at DESC' }, class_name: Doorkeeper::AccessTo
 If you know in advance that you would like to prevent changing the Swagger API URL, you can hide the Swagger UI source URL using the following:
 
 ```ruby
-GrapeSwaggerRails.options.hide_url_input = true
+GrapeSwaggerRails.options.hide_info_url = true
 ```
 
 Similarly, you can hide the Authentication input box by adding this:

--- a/README.md
+++ b/README.md
@@ -260,7 +260,7 @@ has_one :token, -> { order 'created_at DESC' }, class_name: Doorkeeper::AccessTo
 
 ### Hiding the API or Authorization text boxes
 
-If you know in advance that you would like to prevent changing the Swagger API URL, you can hide it using the following:
+If you know in advance that you would like to prevent changing the Swagger API URL, you can hide the Swagger UI source URL using the following:
 
 ```ruby
 GrapeSwaggerRails.options.hide_url_input = true

--- a/README.md
+++ b/README.md
@@ -81,13 +81,12 @@ To expose multiple API specifications in the UI, set `urls` instead of a single 
 ```ruby
 GrapeSwaggerRails.options.urls = [
   { name: 'v1', url: '/api/v1/swagger_doc' },
-  { name: 'v2', url: '/api/v2/swagger_doc' }
+  { name: 'v2', url: '/api/v2/swagger_doc', default: true }
 ]
-GrapeSwaggerRails.options.urls_primary_name = 'v2'
 GrapeSwaggerRails.options.app_url = 'http://localhost:3000'
 ```
 
-When multiple specs are configured, a spec selector dropdown appears in the Swagger UI header. `urls_primary_name` controls which spec is selected by default.
+When multiple specs are configured, a spec selector dropdown appears in the Swagger UI header. Mark one item with `default: true` to select it by default.
 
 To pass native Swagger UI configuration options through to `SwaggerUIBundle`, use `swagger_ui_config`:
 
@@ -260,10 +259,10 @@ has_one :token, -> { order 'created_at DESC' }, class_name: Doorkeeper::AccessTo
 
 ### Hiding the API or Authorization text boxes
 
-If you know in advance that you would like to prevent changing the Swagger API URL, you can hide the Swagger UI source URL using the following:
+If you know in advance that you would like to prevent changing the Swagger API URL, you can hide it using the following:
 
 ```ruby
-GrapeSwaggerRails.options.hide_info_url = true
+GrapeSwaggerRails.options.hide_url_input = true
 ```
 
 Similarly, you can hide the Authentication input box by adding this:
@@ -289,6 +288,15 @@ tests pass and then send PR here.
 * [joelvh](https://github.com/joelvh)
 * [dblock](https://github.com/dblock)
 * ... and [more](https://github.com/ruby-grape/grape-swagger-rails/graphs/contributors) ...
+
+## AI Agents
+
+If you're an AI agent working on this project, read the instructions file for your tool:
+
+- **[CLAUDE.md](CLAUDE.md)** — Claude Code
+- **[.github/copilot-instructions.md](.github/copilot-instructions.md)** — GitHub Copilot
+
+These files contain architecture context, commands, and coding conventions.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -289,15 +289,6 @@ tests pass and then send PR here.
 * [dblock](https://github.com/dblock)
 * ... and [more](https://github.com/ruby-grape/grape-swagger-rails/graphs/contributors) ...
 
-## AI Agents
-
-If you're an AI agent working on this project, read the instructions file for your tool:
-
-- **[CLAUDE.md](CLAUDE.md)** — Claude Code
-- **[.github/copilot-instructions.md](.github/copilot-instructions.md)** — GitHub Copilot
-
-These files contain architecture context, commands, and coding conventions.
-
 ## Contributing
 
 See [CONTRIBUTING](CONTRIBUTING.md).

--- a/app/assets/javascripts/grape_swagger_rails/index.js
+++ b/app/assets/javascripts/grape_swagger_rails/index.js
@@ -142,13 +142,14 @@ function initializeSwaggerPage() {
     function buildPlugins() {
         var configuredPlugins = options.swagger_ui_config && options.swagger_ui_config.plugins;
         var plugins = Array.isArray(configuredPlugins) ? configuredPlugins.slice() : [];
-        if (options.hide_info_url) {
+        var display = options.display || {};
+        if (!display.info_url) {
             plugins.push(hideInfoUrlPlugin);
         }
-        if (options.hide_doc_version) {
+        if (!display.doc_version) {
             plugins.push(hideDocVersionPlugin);
         }
-        if (options.hide_version_stamp) {
+        if (!display.version_stamp) {
             plugins.push(hideVersionStampPlugin);
         }
         return plugins;

--- a/app/assets/javascripts/grape_swagger_rails/index.js
+++ b/app/assets/javascripts/grape_swagger_rails/index.js
@@ -125,10 +125,10 @@ function initializeSwaggerPage() {
             },
         };
     }
-    function swaggerPlugins() {
+    function buildPlugins() {
         var configuredPlugins = options.swagger_ui_config && options.swagger_ui_config.plugins;
         var plugins = Array.isArray(configuredPlugins) ? configuredPlugins.slice() : [];
-        if (options.hide_url_input) {
+        if (options.hide_info_url) {
             plugins.push(hideInfoUrlPlugin);
         }
         return plugins;
@@ -150,7 +150,7 @@ function initializeSwaggerPage() {
         validatorUrl: options.validator_url,
         layout: "BaseLayout",
         presets: [SwaggerUIBundle.presets.apis, SwaggerUIStandalonePreset],
-        plugins: swaggerPlugins(),
+        plugins: buildPlugins(),
         requestInterceptor: function (request) {
             var headers = options.headers || {};
             Object.keys(headers).forEach(function (key) {

--- a/app/assets/javascripts/grape_swagger_rails/index.js
+++ b/app/assets/javascripts/grape_swagger_rails/index.js
@@ -125,11 +125,31 @@ function initializeSwaggerPage() {
             },
         };
     }
+    function hideDocVersionPlugin() {
+        return {
+            wrapComponents: {
+                VersionStamp: function () { return function () { return null; }; },
+            },
+        };
+    }
+    function hideVersionStampPlugin() {
+        return {
+            wrapComponents: {
+                OpenAPIVersion: function () { return function () { return null; }; },
+            },
+        };
+    }
     function buildPlugins() {
         var configuredPlugins = options.swagger_ui_config && options.swagger_ui_config.plugins;
         var plugins = Array.isArray(configuredPlugins) ? configuredPlugins.slice() : [];
         if (options.hide_info_url) {
             plugins.push(hideInfoUrlPlugin);
+        }
+        if (options.hide_doc_version) {
+            plugins.push(hideDocVersionPlugin);
+        }
+        if (options.hide_version_stamp) {
+            plugins.push(hideVersionStampPlugin);
         }
         return plugins;
     }

--- a/app/assets/javascripts/grape_swagger_rails/index.js
+++ b/app/assets/javascripts/grape_swagger_rails/index.js
@@ -118,6 +118,21 @@ function initializeSwaggerPage() {
         });
         specSelectorWrapper.hidden = false;
     }
+    function hideInfoUrlPlugin() {
+        return {
+            wrapComponents: {
+                InfoUrl: function () { return function () { return null; }; },
+            },
+        };
+    }
+    function swaggerPlugins() {
+        var configuredPlugins = options.swagger_ui_config && options.swagger_ui_config.plugins;
+        var plugins = Array.isArray(configuredPlugins) ? configuredPlugins.slice() : [];
+        if (options.hide_url_input) {
+            plugins.push(hideInfoUrlPlugin);
+        }
+        return plugins;
+    }
     applyTheme(getTheme());
     if (themeToggle) {
         themeToggle.addEventListener("click", function () {
@@ -135,6 +150,7 @@ function initializeSwaggerPage() {
         validatorUrl: options.validator_url,
         layout: "BaseLayout",
         presets: [SwaggerUIBundle.presets.apis, SwaggerUIStandalonePreset],
+        plugins: swaggerPlugins(),
         requestInterceptor: function (request) {
             var headers = options.headers || {};
             Object.keys(headers).forEach(function (key) {

--- a/app/assets/javascripts/grape_swagger_rails/index.js
+++ b/app/assets/javascripts/grape_swagger_rails/index.js
@@ -142,7 +142,8 @@ function initializeSwaggerPage() {
     function buildPlugins() {
         var configuredPlugins = options.swagger_ui_config && options.swagger_ui_config.plugins;
         var plugins = Array.isArray(configuredPlugins) ? configuredPlugins.slice() : [];
-        var display = options.display || {};
+        var displayDefaults = { api_key_input: true, info_url: true, doc_version: true, version_stamp: true };
+        var display = Object.assign({}, displayDefaults, options.display || {});
         if (!display.info_url) {
             plugins.push(hideInfoUrlPlugin);
         }

--- a/app/assets/stylesheets/grape_swagger_rails/index.css
+++ b/app/assets/stylesheets/grape_swagger_rails/index.css
@@ -125,6 +125,10 @@ html[data-hide-api-key="true"] .swagger-auth {
   display: none;
 }
 
+html[data-hide-url="true"] .swagger-ui .info > a.link {
+  display: none;
+}
+
 html[data-theme="dark"] .swagger-ui {
   background: transparent;
   color: #e2e8f0;

--- a/app/assets/stylesheets/grape_swagger_rails/index.css
+++ b/app/assets/stylesheets/grape_swagger_rails/index.css
@@ -125,7 +125,7 @@ html[data-hide-api-key="true"] .swagger-auth {
   display: none;
 }
 
-html[data-hide-url="true"] .swagger-ui .info > a.link {
+html[data-hide-info-url="true"] .swagger-ui .info > a.link {
   display: none;
 }
 

--- a/app/helpers/grape_swagger_rails/application_helper.rb
+++ b/app/helpers/grape_swagger_rails/application_helper.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module GrapeSwaggerRails
+  # View helpers for the Swagger UI page.
+  module ApplicationHelper
+    def swagger_data_attributes
+      options = GrapeSwaggerRails.options
+
+      {
+        swagger_options: options.marshal_dump.to_json,
+        hide_api_key: options.hide_api_key_input,
+        hide_url: options.hide_url_input
+      }
+    end
+  end
+end

--- a/app/helpers/grape_swagger_rails/application_helper.rb
+++ b/app/helpers/grape_swagger_rails/application_helper.rb
@@ -9,7 +9,7 @@ module GrapeSwaggerRails
       {
         swagger_options: options.marshal_dump.to_json,
         hide_api_key: options.hide_api_key_input,
-        hide_url: options.hide_url_input
+        hide_info_url: options.hide_info_url
       }
     end
   end

--- a/app/helpers/grape_swagger_rails/application_helper.rb
+++ b/app/helpers/grape_swagger_rails/application_helper.rb
@@ -5,11 +5,12 @@ module GrapeSwaggerRails
   module ApplicationHelper
     def swagger_data_attributes
       options = GrapeSwaggerRails.options
+      display = options.display || {}
 
       {
         swagger_options: options.marshal_dump.to_json,
-        hide_api_key: options.hide_api_key_input,
-        hide_info_url: options.hide_info_url
+        hide_api_key: !display[:api_key_input],
+        hide_info_url: !display[:info_url]
       }
     end
   end

--- a/app/helpers/grape_swagger_rails/application_helper.rb
+++ b/app/helpers/grape_swagger_rails/application_helper.rb
@@ -5,7 +5,8 @@ module GrapeSwaggerRails
   module ApplicationHelper
     def swagger_data_attributes
       options = GrapeSwaggerRails.options
-      display = options.display || {}
+      display_defaults = { api_key_input: true, info_url: true, doc_version: true, version_stamp: true }
+      display = display_defaults.merge((options.display || {}).transform_keys(&:to_sym))
 
       {
         swagger_options: options.marshal_dump.to_json,

--- a/app/views/grape_swagger_rails/application/index.html.haml
+++ b/app/views/grape_swagger_rails/application/index.html.haml
@@ -1,5 +1,5 @@
 !!! 5
-%html{ data: { swagger_options: GrapeSwaggerRails.options.marshal_dump.to_json, hide_api_key: GrapeSwaggerRails.options.hide_api_key_input } }
+%html{ data: { swagger_options: GrapeSwaggerRails.options.marshal_dump.to_json, hide_api_key: GrapeSwaggerRails.options.hide_api_key_input, hide_url: GrapeSwaggerRails.options.hide_url_input } }
   %head
     %title= GrapeSwaggerRails.options.app_name || 'Swagger UI'
     %meta{ charset: 'utf-8' }

--- a/app/views/grape_swagger_rails/application/index.html.haml
+++ b/app/views/grape_swagger_rails/application/index.html.haml
@@ -1,5 +1,5 @@
 !!! 5
-%html{ data: { swagger_options: GrapeSwaggerRails.options.marshal_dump.to_json, hide_api_key: GrapeSwaggerRails.options.hide_api_key_input, hide_url: GrapeSwaggerRails.options.hide_url_input } }
+%html{ data: swagger_data_attributes }
   %head
     %title= GrapeSwaggerRails.options.app_name || 'Swagger UI'
     %meta{ charset: 'utf-8' }

--- a/frontend/grape_swagger_rails/index.ts
+++ b/frontend/grape_swagger_rails/index.ts
@@ -38,6 +38,10 @@ interface SwaggerRequest {
   headers?: Record<string, string> | Headers;
 }
 
+interface SwaggerPlugin {
+  wrapComponents?: Record<string, unknown>;
+}
+
 declare const SwaggerUIBundle: any;
 declare const SwaggerUIStandalonePreset: any;
 
@@ -196,6 +200,25 @@ function initializeSwaggerPage(): void {
     specSelectorWrapper.hidden = false;
   }
 
+  function hideInfoUrlPlugin(): SwaggerPlugin {
+    return {
+      wrapComponents: {
+        InfoUrl: () => () => null,
+      },
+    };
+  }
+
+  function swaggerPlugins(): unknown[] {
+    const configuredPlugins = options.swagger_ui_config && options.swagger_ui_config.plugins;
+    const plugins = Array.isArray(configuredPlugins) ? configuredPlugins.slice() : [];
+
+    if (options.hide_url_input) {
+      plugins.push(hideInfoUrlPlugin);
+    }
+
+    return plugins;
+  }
+
   applyTheme(getTheme());
 
   if (themeToggle) {
@@ -216,6 +239,7 @@ function initializeSwaggerPage(): void {
     validatorUrl: options.validator_url,
     layout: "BaseLayout",
     presets: [SwaggerUIBundle.presets.apis, SwaggerUIStandalonePreset],
+    plugins: swaggerPlugins(),
     requestInterceptor: (request: SwaggerRequest) => {
       const headers = options.headers || {};
       Object.keys(headers).forEach((key) => {

--- a/frontend/grape_swagger_rails/index.ts
+++ b/frontend/grape_swagger_rails/index.ts
@@ -14,6 +14,8 @@ interface SwaggerPageOptions {
   headers: Record<string, string>;
   hide_api_key_input: boolean;
   hide_info_url: boolean;
+  hide_doc_version: boolean;
+  hide_version_stamp: boolean;
   supported_submit_methods: string[];
   theme: string;
   url: string;
@@ -208,12 +210,36 @@ function initializeSwaggerPage(): void {
     };
   }
 
+  function hideDocVersionPlugin(): SwaggerPlugin {
+    return {
+      wrapComponents: {
+        VersionStamp: () => () => null,
+      },
+    };
+  }
+
+  function hideVersionStampPlugin(): SwaggerPlugin {
+    return {
+      wrapComponents: {
+        OpenAPIVersion: () => () => null,
+      },
+    };
+  }
+
   function buildPlugins(): unknown[] {
     const configuredPlugins = options.swagger_ui_config && options.swagger_ui_config.plugins;
     const plugins = Array.isArray(configuredPlugins) ? configuredPlugins.slice() : [];
 
     if (options.hide_info_url) {
       plugins.push(hideInfoUrlPlugin);
+    }
+
+    if (options.hide_doc_version) {
+      plugins.push(hideDocVersionPlugin);
+    }
+
+    if (options.hide_version_stamp) {
+      plugins.push(hideVersionStampPlugin);
     }
 
     return plugins;

--- a/frontend/grape_swagger_rails/index.ts
+++ b/frontend/grape_swagger_rails/index.ts
@@ -231,7 +231,8 @@ function initializeSwaggerPage(): void {
   function buildPlugins(): unknown[] {
     const configuredPlugins = options.swagger_ui_config && options.swagger_ui_config.plugins;
     const plugins = Array.isArray(configuredPlugins) ? configuredPlugins.slice() : [];
-    const display = options.display || {};
+    const displayDefaults = { api_key_input: true, info_url: true, doc_version: true, version_stamp: true };
+    const display = Object.assign({}, displayDefaults, options.display || {});
 
     if (!display.info_url) {
       plugins.push(hideInfoUrlPlugin);

--- a/frontend/grape_swagger_rails/index.ts
+++ b/frontend/grape_swagger_rails/index.ts
@@ -12,10 +12,12 @@ interface SwaggerPageOptions {
   app_url: string;
   doc_expansion: string;
   headers: Record<string, string>;
-  hide_api_key_input: boolean;
-  hide_info_url: boolean;
-  hide_doc_version: boolean;
-  hide_version_stamp: boolean;
+  display: {
+    api_key_input: boolean;
+    info_url: boolean;
+    doc_version: boolean;
+    version_stamp: boolean;
+  };
   supported_submit_methods: string[];
   theme: string;
   url: string;
@@ -229,16 +231,17 @@ function initializeSwaggerPage(): void {
   function buildPlugins(): unknown[] {
     const configuredPlugins = options.swagger_ui_config && options.swagger_ui_config.plugins;
     const plugins = Array.isArray(configuredPlugins) ? configuredPlugins.slice() : [];
+    const display = options.display || {};
 
-    if (options.hide_info_url) {
+    if (!display.info_url) {
       plugins.push(hideInfoUrlPlugin);
     }
 
-    if (options.hide_doc_version) {
+    if (!display.doc_version) {
       plugins.push(hideDocVersionPlugin);
     }
 
-    if (options.hide_version_stamp) {
+    if (!display.version_stamp) {
       plugins.push(hideVersionStampPlugin);
     }
 

--- a/frontend/grape_swagger_rails/index.ts
+++ b/frontend/grape_swagger_rails/index.ts
@@ -13,7 +13,7 @@ interface SwaggerPageOptions {
   doc_expansion: string;
   headers: Record<string, string>;
   hide_api_key_input: boolean;
-  hide_url_input: boolean;
+  hide_info_url: boolean;
   supported_submit_methods: string[];
   theme: string;
   url: string;
@@ -208,11 +208,11 @@ function initializeSwaggerPage(): void {
     };
   }
 
-  function swaggerPlugins(): unknown[] {
+  function buildPlugins(): unknown[] {
     const configuredPlugins = options.swagger_ui_config && options.swagger_ui_config.plugins;
     const plugins = Array.isArray(configuredPlugins) ? configuredPlugins.slice() : [];
 
-    if (options.hide_url_input) {
+    if (options.hide_info_url) {
       plugins.push(hideInfoUrlPlugin);
     }
 
@@ -239,7 +239,7 @@ function initializeSwaggerPage(): void {
     validatorUrl: options.validator_url,
     layout: "BaseLayout",
     presets: [SwaggerUIBundle.presets.apis, SwaggerUIStandalonePreset],
-    plugins: swaggerPlugins(),
+    plugins: buildPlugins(),
     requestInterceptor: (request: SwaggerRequest) => {
       const headers = options.headers || {};
       Object.keys(headers).forEach((key) => {

--- a/lib/grape-swagger-rails.rb
+++ b/lib/grape-swagger-rails.rb
@@ -49,6 +49,8 @@ module GrapeSwaggerRails
     before_action_proc: nil, # Proc used as a controller before action
 
     hide_info_url: false,
+    hide_doc_version: false,
+    hide_version_stamp: false,
     hide_api_key_input: false
   )
 

--- a/lib/grape-swagger-rails.rb
+++ b/lib/grape-swagger-rails.rb
@@ -48,7 +48,7 @@ module GrapeSwaggerRails
 
     before_action_proc: nil, # Proc used as a controller before action
 
-    hide_url_input: false,
+    hide_info_url: false,
     hide_api_key_input: false
   )
 

--- a/lib/grape-swagger-rails.rb
+++ b/lib/grape-swagger-rails.rb
@@ -48,10 +48,12 @@ module GrapeSwaggerRails
 
     before_action_proc: nil, # Proc used as a controller before action
 
-    hide_info_url: false,
-    hide_doc_version: false,
-    hide_version_stamp: false,
-    hide_api_key_input: false
+    display: {
+      api_key_input: true,
+      info_url: true,
+      doc_version: true,
+      version_stamp: true
+    }
   )
 
   def self.deprecator

--- a/spec/features/swagger_spec.rb
+++ b/spec/features/swagger_spec.rb
@@ -137,13 +137,17 @@ describe 'Swagger' do
     expect(GrapeSwaggerRails::VERSION).not_to be_blank
   end
 
-  describe 'hide_info_url option' do
+  shared_context 'with isolated options' do
     around do |example|
       options = GrapeSwaggerRails.options.dup
       example.run
     ensure
       GrapeSwaggerRails.options = options
     end
+  end
+
+  describe 'hide_info_url option' do
+    include_context 'with isolated options'
 
     it 'hides its own documentation routes by default' do
       api = build_documented_api
@@ -168,6 +172,45 @@ describe 'Swagger' do
         '/api/swagger_doc(.json)',
         '/api/swagger_doc/:name(.json)'
       )
+    end
+  end
+
+  describe 'hide_doc_version option' do
+    include_context 'with isolated options'
+
+    it 'shows the document version by default' do
+      visit_swagger
+
+      # The VersionStamp component renders info.version outside of .version-stamp
+      expect(page).to have_css('.swagger-ui .info small:not(.version-stamp) .version')
+    end
+
+    it 'hides the document version when enabled' do
+      GrapeSwaggerRails.options.hide_doc_version = true
+      visit_swagger
+
+      # VersionStamp is suppressed, but the OAS badge (.version-stamp) remains
+      expect(page).to have_no_css('.swagger-ui .info small:not(.version-stamp) .version')
+      expect(page).to have_css('.swagger-ui .info .version-stamp .version', text: 'OAS 2.0')
+    end
+  end
+
+  describe 'hide_version_stamp option' do
+    include_context 'with isolated options'
+
+    it 'shows the OAS version stamp by default' do
+      visit_swagger
+
+      expect(page).to have_css('.swagger-ui .info .version-stamp .version', text: 'OAS 2.0')
+    end
+
+    it 'hides the OAS version stamp when enabled' do
+      GrapeSwaggerRails.options.hide_version_stamp = true
+      visit_swagger
+
+      expect(page).to have_no_css('.swagger-ui .info .version-stamp')
+      # The document version (VersionStamp) remains visible
+      expect(page).to have_css('.swagger-ui .info small:not(.version-stamp) .version')
     end
   end
 

--- a/spec/features/swagger_spec.rb
+++ b/spec/features/swagger_spec.rb
@@ -139,30 +139,20 @@ describe 'Swagger' do
 
   shared_context 'with isolated options' do
     around do |example|
-      options = GrapeSwaggerRails.options.dup
+      saved = GrapeSwaggerRails.options
+      deep = saved.marshal_dump.transform_values { |v| v.dup rescue v }
+      deep[:before_action_proc] = saved.before_action_proc
       example.run
     ensure
-      GrapeSwaggerRails.options = options
+      GrapeSwaggerRails.options = GrapeSwaggerRails::Options.new(**deep)
     end
   end
 
-  describe 'display[:info_url] option' do
-    include_context 'with isolated options'
-
+  describe 'hide_documentation_path behavior' do
     it 'hides its own documentation routes by default' do
       api = build_documented_api
 
       expect(swagger_documentation_route_paths(api)).to be_empty
-    end
-
-    it 'does not render its own documentation path in Swagger UI' do
-      GrapeSwaggerRails.options.display = GrapeSwaggerRails.options.display.merge(info_url: false)
-      visit_swagger
-
-      expect(swagger_document.fetch('paths').keys.grep(/swagger_doc/)).to be_empty
-      expect(page).to have_no_css('.swagger-ui .info a.link[href="http://localhost:3000/api/swagger_doc"]')
-      expect(page).to have_css('.opblock-tag', text: 'foos')
-      expect(page).to have_no_css('.opblock-tag, .opblock-summary-path', text: 'swagger_doc')
     end
 
     it 'includes its own documentation routes when disabled' do
@@ -172,6 +162,29 @@ describe 'Swagger' do
         '/api/swagger_doc(.json)',
         '/api/swagger_doc/:name(.json)'
       )
+    end
+
+    it 'does not include swagger_doc paths in the served document' do
+      expect(swagger_document.fetch('paths').keys.grep(/swagger_doc/)).to be_empty
+    end
+  end
+
+  describe 'display[:info_url] option' do
+    include_context 'with isolated options'
+
+    it 'shows the info URL link by default' do
+      visit_swagger
+
+      expect(page).to have_css('.swagger-ui .info a.link')
+    end
+
+    it 'hides the info URL link when disabled' do
+      GrapeSwaggerRails.options.display = GrapeSwaggerRails.options.display.merge(info_url: false)
+      visit_swagger
+
+      expect(page).to have_no_css('.swagger-ui .info a.link[href="http://localhost:3000/api/swagger_doc"]')
+      expect(page).to have_css('.opblock-tag', text: 'foos')
+      expect(page).to have_no_css('.opblock-tag, .opblock-summary-path', text: 'swagger_doc')
     end
   end
 

--- a/spec/features/swagger_spec.rb
+++ b/spec/features/swagger_spec.rb
@@ -16,6 +16,23 @@ describe 'Swagger' do
     JSON.parse(session.html)
   end
 
+  def build_documented_api(swagger_options = {})
+    Class.new(Grape::API) do
+      prefix 'api'
+
+      desc 'Get health.'
+      get '/health' do
+        { status: 'ok' }
+      end
+
+      add_swagger_documentation(swagger_options)
+    end
+  end
+
+  def swagger_documentation_route_paths(api)
+    api.combined_namespace_routes.fetch('swagger_doc').map(&:path)
+  end
+
   def swagger_configs
     page.evaluate_script(<<~JS)
       (function() {
@@ -118,6 +135,40 @@ describe 'Swagger' do
   it "uses grape-swagger=#{GrapeSwagger::VERSION} grape-swagger-rails=#{GrapeSwaggerRails::VERSION}" do
     expect(GrapeSwagger::VERSION).not_to be_blank
     expect(GrapeSwaggerRails::VERSION).not_to be_blank
+  end
+
+  describe 'add_swagger_documentation hide_documentation_path' do
+    around do |example|
+      options = GrapeSwaggerRails.options.dup
+      example.run
+    ensure
+      GrapeSwaggerRails.options = options
+    end
+
+    it 'hides its own documentation routes by default' do
+      api = build_documented_api
+
+      expect(swagger_documentation_route_paths(api)).to be_empty
+    end
+
+    it 'does not render its own documentation path in Swagger UI' do
+      GrapeSwaggerRails.options.hide_url_input = false
+      visit_swagger
+
+      expect(swagger_document.fetch('paths').keys.grep(/swagger_doc/)).to be_empty
+      expect(page).to have_no_css('.swagger-ui .info a.link[href="http://localhost:3000/api/swagger_doc"]')
+      expect(page).to have_css('.opblock-tag', text: 'foos')
+      expect(page).to have_no_css('.opblock-tag, .opblock-summary-path', text: 'swagger_doc')
+    end
+
+    it 'includes its own documentation routes when disabled' do
+      api = build_documented_api(hide_documentation_path: false)
+
+      expect(swagger_documentation_route_paths(api)).to contain_exactly(
+        '/api/swagger_doc(.json)',
+        '/api/swagger_doc/:name(.json)'
+      )
+    end
   end
 
   context 'swaggerUi' do

--- a/spec/features/swagger_spec.rb
+++ b/spec/features/swagger_spec.rb
@@ -137,7 +137,7 @@ describe 'Swagger' do
     expect(GrapeSwaggerRails::VERSION).not_to be_blank
   end
 
-  describe 'add_swagger_documentation hide_documentation_path' do
+  describe 'hide_info_url option' do
     around do |example|
       options = GrapeSwaggerRails.options.dup
       example.run
@@ -152,7 +152,7 @@ describe 'Swagger' do
     end
 
     it 'does not render its own documentation path in Swagger UI' do
-      GrapeSwaggerRails.options.hide_url_input = true
+      GrapeSwaggerRails.options.hide_info_url = true
       visit_swagger
 
       expect(swagger_document.fetch('paths').keys.grep(/swagger_doc/)).to be_empty

--- a/spec/features/swagger_spec.rb
+++ b/spec/features/swagger_spec.rb
@@ -146,7 +146,7 @@ describe 'Swagger' do
     end
   end
 
-  describe 'hide_info_url option' do
+  describe 'display[:info_url] option' do
     include_context 'with isolated options'
 
     it 'hides its own documentation routes by default' do
@@ -156,7 +156,7 @@ describe 'Swagger' do
     end
 
     it 'does not render its own documentation path in Swagger UI' do
-      GrapeSwaggerRails.options.hide_info_url = true
+      GrapeSwaggerRails.options.display = GrapeSwaggerRails.options.display.merge(info_url: false)
       visit_swagger
 
       expect(swagger_document.fetch('paths').keys.grep(/swagger_doc/)).to be_empty
@@ -175,7 +175,7 @@ describe 'Swagger' do
     end
   end
 
-  describe 'hide_doc_version option' do
+  describe 'display[:doc_version] option' do
     include_context 'with isolated options'
 
     it 'shows the document version by default' do
@@ -185,8 +185,8 @@ describe 'Swagger' do
       expect(page).to have_css('.swagger-ui .info small:not(.version-stamp) .version')
     end
 
-    it 'hides the document version when enabled' do
-      GrapeSwaggerRails.options.hide_doc_version = true
+    it 'hides the document version when disabled' do
+      GrapeSwaggerRails.options.display = GrapeSwaggerRails.options.display.merge(doc_version: false)
       visit_swagger
 
       # VersionStamp is suppressed, but the OAS badge (.version-stamp) remains
@@ -195,7 +195,7 @@ describe 'Swagger' do
     end
   end
 
-  describe 'hide_version_stamp option' do
+  describe 'display[:version_stamp] option' do
     include_context 'with isolated options'
 
     it 'shows the OAS version stamp by default' do
@@ -204,8 +204,8 @@ describe 'Swagger' do
       expect(page).to have_css('.swagger-ui .info .version-stamp .version', text: 'OAS 2.0')
     end
 
-    it 'hides the OAS version stamp when enabled' do
-      GrapeSwaggerRails.options.hide_version_stamp = true
+    it 'hides the OAS version stamp when disabled' do
+      GrapeSwaggerRails.options.display = GrapeSwaggerRails.options.display.merge(version_stamp: false)
       visit_swagger
 
       expect(page).to have_no_css('.swagger-ui .info .version-stamp')
@@ -331,6 +331,7 @@ describe 'Swagger' do
     it 'evaluates config options correctly' do
       visit_swagger
       page_options = swagger_options_data.symbolize_keys
+      page_options[:display] = page_options[:display].symbolize_keys if page_options[:display].is_a?(Hash)
       expect(page_options).to eq(@options.marshal_dump)
     end
 

--- a/spec/features/swagger_spec.rb
+++ b/spec/features/swagger_spec.rb
@@ -140,7 +140,11 @@ describe 'Swagger' do
   shared_context 'with isolated options' do
     around do |example|
       saved = GrapeSwaggerRails.options
-      deep = saved.marshal_dump.transform_values { |v| v.dup rescue v }
+      deep = saved.marshal_dump.transform_values do |v|
+        v.dup
+      rescue TypeError
+        v
+      end
       deep[:before_action_proc] = saved.before_action_proc
       example.run
     ensure

--- a/spec/features/swagger_spec.rb
+++ b/spec/features/swagger_spec.rb
@@ -152,7 +152,7 @@ describe 'Swagger' do
     end
 
     it 'does not render its own documentation path in Swagger UI' do
-      GrapeSwaggerRails.options.hide_url_input = false
+      GrapeSwaggerRails.options.hide_url_input = true
       visit_swagger
 
       expect(swagger_document.fetch('paths').keys.grep(/swagger_doc/)).to be_empty


### PR DESCRIPTION
Replaces the scattered `hide_url_input`, `hide_api_key_input`, `hide_doc_version`, and `hide_version_stamp` boolean flags with a single display hash using positive semantics:
```ruby
GrapeSwaggerRails.options.display = {
  api_key_input: true,
  info_url: true,
  doc_version: true,
  version_stamp: true
}
```

### Changes
- New display option - groups all UI element visibility controls; true means shown, false means hidden
- display[:doc_version] - hides the API document version (info.version) via Swagger UI VersionStamp component wrapper
- display[:version_stamp] - hides the OAS version badge (e.g. "OAS 2.0") via OpenAPIVersion component wrapper
- Renamed hide_url_input -> display[:info_url] - the old name referenced the legacy Swagger UI v1/v2 URL input field which no longer exists; the flag now controls the info URL link in modern Swagger UI
- Renamed hide_api_key_input -> display[:api_key_input] - controls visibility of the API key input in the header bar
Shared spec context - extracted the repeated around block into shared_context 'with isolated options'