### PR TITLE
Replace `urls_primary_name` with per-item `default: true`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * [#142](https://github.com/ruby-grape/grape-swagger-rails/pull/142): Convert view to haml and extract javascript to typescript - [@moskvin](https://github.com/moskvin).
 * [#143](https://github.com/ruby-grape/grape-swagger-rails/pull/143): Add swagger_ui_config pass-through to swaggeruibundle - [@moskvin](https://github.com/moskvin).
 * [#144](https://github.com/ruby-grape/grape-swagger-rails/pull/144): Add support for multiple api specifications in swagger ui - [@moskvin](https://github.com/moskvin).
+* [#147](https://github.com/ruby-grape/grape-swagger-rails/pull/147): Replace `urls_primary_name` with per-item `default: true` - [@moskvin](https://github.com/moskvin).
 * [#146](https://github.com/ruby-grape/grape-swagger-rails/pull/146): Consolidate UI visibility flags into display options hash - [@moskvin](https://github.com/moskvin).
 * Your contribution here.
 

--- a/app/assets/javascripts/grape_swagger_rails/index.js
+++ b/app/assets/javascripts/grape_swagger_rails/index.js
@@ -73,11 +73,12 @@ function initializeSwaggerPage() {
         return options.urls
             .map(function (entry, index) {
             if (typeof entry === "string") {
-                return { name: entry, url: absoluteSpecUrl(entry) };
+                return { name: entry, url: absoluteSpecUrl(entry), default: false };
             }
             return {
                 name: entry.name || entry.url || "Spec " + (index + 1),
                 url: absoluteSpecUrl(entry.url),
+                default: Boolean(entry.default),
             };
         })
             .filter(function (entry) { return Boolean(entry.url); });
@@ -86,11 +87,9 @@ function initializeSwaggerPage() {
         if (!urls.length) {
             return null;
         }
-        if (options.urls_primary_name) {
-            for (var i = 0; i < urls.length; i += 1) {
-                if (urls[i].name === options.urls_primary_name) {
-                    return urls[i];
-                }
+        for (var i = 0; i < urls.length; i += 1) {
+            if (urls[i].default) {
+                return urls[i];
             }
         }
         if (options.url) {

--- a/frontend/grape_swagger_rails/index.ts
+++ b/frontend/grape_swagger_rails/index.ts
@@ -22,7 +22,6 @@ interface SwaggerPageOptions {
   theme: string;
   url: string;
   urls: Array<string | SwaggerUrlOption> | null;
-  urls_primary_name: string;
   validator_url: string | null | undefined;
   swagger_ui_config?: Record<string, unknown>;
 }
@@ -30,11 +29,13 @@ interface SwaggerPageOptions {
 interface SwaggerUrlOption {
   name?: string;
   url: string;
+  default?: boolean;
 }
 
 interface NormalizedSwaggerUrl {
   name: string;
   url: string;
+  default: boolean;
 }
 
 interface SwaggerRequest {
@@ -147,12 +148,13 @@ function initializeSwaggerPage(): void {
     return options.urls
       .map((entry, index): NormalizedSwaggerUrl => {
         if (typeof entry === "string") {
-          return { name: entry, url: absoluteSpecUrl(entry) };
+          return { name: entry, url: absoluteSpecUrl(entry), default: false };
         }
 
         return {
           name: entry.name || entry.url || "Spec " + (index + 1),
           url: absoluteSpecUrl(entry.url),
+          default: Boolean(entry.default),
         };
       })
       .filter((entry) => Boolean(entry.url));
@@ -163,11 +165,9 @@ function initializeSwaggerPage(): void {
       return null;
     }
 
-    if (options.urls_primary_name) {
-      for (let i = 0; i < urls.length; i += 1) {
-        if (urls[i].name === options.urls_primary_name) {
-          return urls[i];
-        }
+    for (let i = 0; i < urls.length; i += 1) {
+      if (urls[i].default) {
+        return urls[i];
       }
     }
 

--- a/lib/grape-swagger-rails.rb
+++ b/lib/grape-swagger-rails.rb
@@ -28,7 +28,6 @@ module GrapeSwaggerRails
   self.options = Options.new(
     url: '/swagger_doc',
     urls: nil,
-    urls_primary_name: '',
     swagger_ui_config: {},
     app_name: 'Swagger',
     app_url: '',

--- a/spec/features/swagger_spec.rb
+++ b/spec/features/swagger_spec.rb
@@ -397,9 +397,8 @@ describe 'Swagger' do
       before do
         GrapeSwaggerRails.options.urls = [
           { name: 'v1', url: '/api/swagger_doc' },
-          { name: 'v2', url: '/api/v2/swagger_doc' }
+          { name: 'v2', url: '/api/v2/swagger_doc', default: true }
         ]
-        GrapeSwaggerRails.options.urls_primary_name = 'v2'
         GrapeSwaggerRails.options.url = '/api/swagger_doc'
         visit_swagger
       end
@@ -427,6 +426,21 @@ describe 'Swagger' do
         # v1 exposes foos namespace; wait for it to appear in the rendered spec
         expect(page).to have_css('.opblock-tag', text: 'foos', wait: 10)
         expect(page).to have_no_css('.errors-wrapper')
+      end
+
+      context 'when no url has default: true' do
+        before do
+          GrapeSwaggerRails.options.urls = [
+            { name: 'v1', url: '/api/swagger_doc' },
+            { name: 'v2', url: '/api/v2/swagger_doc' }
+          ]
+          GrapeSwaggerRails.options.url = '/api/swagger_doc'
+          visit_swagger
+        end
+
+        it 'falls back to the url option to determine the default selection' do
+          expect(page).to have_select('spec-selector', selected: 'v1', options: %w[v1 v2])
+        end
       end
     end
 


### PR DESCRIPTION
Replaces the separate urls_primary_name string option with a `default: true` flag on individual URL entries