### PR TITLE
Remove extra label placeholder from Swagger UI

### DIFF
--- a/app/views/grape_swagger_rails/application/index.html.haml
+++ b/app/views/grape_swagger_rails/application/index.html.haml
@@ -14,7 +14,6 @@
         %label#spec-selector-wrapper.swagger-auth{ hidden: true }
           %select#spec-selector.swagger-select{ name: 'spec-selector' }
         %label.swagger-auth
-          %span.swagger-label= GrapeSwaggerRails.options.api_key_placeholder
           %input#input_apiKey.swagger-input{ name: 'apiKey', type: 'text', value: GrapeSwaggerRails.options.api_key_default_value, placeholder: GrapeSwaggerRails.options.api_key_placeholder }
     #swagger-ui-container
     = javascript_include_tag 'grape_swagger_rails/swagger-ui-bundle'

--- a/spec/features/swagger_spec.rb
+++ b/spec/features/swagger_spec.rb
@@ -485,6 +485,7 @@ describe 'Swagger' do
 
       it 'adds a custom placeholder' do
         expect(find_by_id('input_apiKey')['placeholder']).to eq 'authorization_code'
+        expect(page).to have_no_css('.swagger-auth .swagger-label')
       end
     end
 


### PR DESCRIPTION
Replaces the visible `%span.swagger-label` with the `placeholder:` attribute directly on the input, removing the redundant label element.

* [#148](https://github.com/ruby-grape/grape-swagger-rails/pull/148): Remove extra label placeholder from Swagger UI - [@moskvin](https://github.com/moskvin).