### PR TITLE
Remove unused application.js and application.css from Sprockets precompile list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ### Next Release
 
+* [#150](https://github.com/ruby-grape/grape-swagger-rails/pull/150): Remove unused application.js and application.css from Sprockets precompile list - [@moskvin](https://github.com/moskvin).
 * [#149](https://github.com/ruby-grape/grape-swagger-rails/pull/149): Add CLAUDE.md and copilot-instructions.md for AI agent guidance - [@moskvin](https://github.com/moskvin).
 * [#138](https://github.com/ruby-grape/grape-swagger-rails/pull/138): Migrate Danger to use danger-pr-comment workflow - [@dblock](https://github.com/dblock).
 * [#140](https://github.com/ruby-grape/grape-swagger-rails/pull/140): Update CI matrix and compatibility documentation - [@moskvin](https://github.com/moskvin).

--- a/lib/grape-swagger-rails/engine.rb
+++ b/lib/grape-swagger-rails/engine.rb
@@ -11,8 +11,6 @@ module GrapeSwaggerRails
         sprockets_4_or_later = Gem::Version.new(Sprockets::VERSION) >= Gem::Version.new('4')
 
         %w[
-          grape_swagger_rails/application.js
-          grape_swagger_rails/application.css
           grape_swagger_rails/favicon.ico
           grape_swagger_rails/swagger-ui.css
           grape_swagger_rails/index.css


### PR DESCRIPTION
The Swagger UI v5 upgrade replaced `application.js` and `application.css` with dedicated asset files (`swagger-ui.css`, `index.css`, etc.). These legacy manifest entries in `engine.rb` are no longer needed.

* [#150](https://github.com/ruby-grape/grape-swagger-rails/pull/150): Remove unused application.js and application.css from Sprockets precompile list - [@moskvin](https://github.com/moskvin).