### PR TITLE
:bug: Enhance dark mode styling and improve API key documentation in Swagger UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ### Next Release
 
+* [#170](https://github.com/ruby-grape/grape-swagger-rails/pull/170): :bug: enhance dark mode styling and improve api key documentation in swagger ui - [@moskvin](https://github.com/moskvin).
 * Your contribution here.
 
 ### 1.0.4 (2026/07/03)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ### Next Release
 
-* [#170](https://github.com/ruby-grape/grape-swagger-rails/pull/170): :bug: enhance dark mode styling and improve api key documentation in swagger ui - [@moskvin](https://github.com/moskvin).
+* [#170](https://github.com/ruby-grape/grape-swagger-rails/pull/170): Enhance dark mode styling and improve api key documentation in swagger ui - [@moskvin](https://github.com/moskvin).
 * Your contribution here.
 
 ### 1.0.4 (2026/07/03)

--- a/app/assets/stylesheets/grape_swagger_rails/index.css
+++ b/app/assets/stylesheets/grape_swagger_rails/index.css
@@ -211,8 +211,6 @@ html[data-theme="dark"] .swagger-ui .renderedMarkdown code,
 html[data-theme="dark"] .swagger-ui .markdown code {
   background: #0f172a;
   color: #c4b5fd;
-  display: inline-block;
-  vertical-align: middle;
   padding: 1px 5px;
 }
 

--- a/app/assets/stylesheets/grape_swagger_rails/index.css
+++ b/app/assets/stylesheets/grape_swagger_rails/index.css
@@ -157,6 +157,17 @@ html[data-theme="dark"] .swagger-select option {
   display: none;
 }
 
+.swagger-ui .btn.authorize {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.swagger-ui .btn.authorize span {
+  float: none;
+  padding: 0;
+}
+
 html[data-hide-api-key="true"] .swagger-auth {
   display: none;
 }
@@ -191,9 +202,29 @@ html[data-theme="dark"] .swagger-ui .responses-inner,
 html[data-theme="dark"] .swagger-ui .opblock .opblock-section-header,
 html[data-theme="dark"] .swagger-ui .opblock-body pre,
 html[data-theme="dark"] .swagger-ui .highlight-code,
-html[data-theme="dark"] .swagger-ui .microlight,
+html[data-theme="dark"] .swagger-ui .microlight {
+  background: #0f172a;
+  color: #e2e8f0;
+}
+
 html[data-theme="dark"] .swagger-ui .renderedMarkdown code,
-html[data-theme="dark"] .swagger-ui .renderedMarkdown pre {
+html[data-theme="dark"] .swagger-ui .markdown code {
+  background: #0f172a;
+  color: #c4b5fd;
+  display: inline-block;
+  vertical-align: middle;
+  padding: 1px 5px;
+}
+
+html[data-theme="dark"] .swagger-ui .renderedMarkdown pre > code,
+html[data-theme="dark"] .swagger-ui .markdown pre > code {
+  display: block;
+  background: transparent;
+  color: inherit;
+}
+
+html[data-theme="dark"] .swagger-ui .renderedMarkdown pre,
+html[data-theme="dark"] .swagger-ui .markdown pre {
   background: #0f172a;
   color: #e2e8f0;
 }

--- a/app/assets/stylesheets/grape_swagger_rails/index.css
+++ b/app/assets/stylesheets/grape_swagger_rails/index.css
@@ -221,6 +221,7 @@ html[data-theme="dark"] .swagger-ui .markdown pre > code {
   display: block;
   background: transparent;
   color: inherit;
+  padding: 0;
 }
 
 html[data-theme="dark"] .swagger-ui .renderedMarkdown pre,

--- a/app/assets/stylesheets/grape_swagger_rails/index.css
+++ b/app/assets/stylesheets/grape_swagger_rails/index.css
@@ -207,11 +207,21 @@ html[data-theme="dark"] .swagger-ui .microlight {
   color: #e2e8f0;
 }
 
+.swagger-ui .markdown,
+.swagger-ui .renderedMarkdown {
+  line-height: 1.2em;
+}
+
+.swagger-ui .markdown code,
+.swagger-ui .renderedMarkdown code {
+  padding: 2px 5px;
+  font-size: 1em;
+}
+
 html[data-theme="dark"] .swagger-ui .renderedMarkdown code,
 html[data-theme="dark"] .swagger-ui .markdown code {
   background: #0f172a;
   color: #c4b5fd;
-  padding: 1px 5px;
 }
 
 html[data-theme="dark"] .swagger-ui .renderedMarkdown pre > code,

--- a/spec/dummy/app/api/api.rb
+++ b/spec/dummy/app/api/api.rb
@@ -84,7 +84,7 @@ class API < Grape::API
           The default API authentication token.<br>
           <br>
           Fetch using the <code>POST /api/auth</code> endpoint.<br>
-          Then use format: <code>Bearer {token}</code> or someting to have extra info with <code>long extra code block</code>
+          Then use format: <code>Bearer {token}</code> or something to have extra info with <code>a long extra code block</code>
         HTML
       }
     }

--- a/spec/dummy/app/api/api.rb
+++ b/spec/dummy/app/api/api.rb
@@ -81,10 +81,11 @@ class API < Grape::API
         name: 'Authorization',
         in: 'header',
         description: <<~HTML
-          The default API authentication token.<br>
+          The default API authentication token.
           <br>
-          Fetch using the <code>POST /api/auth</code> endpoint.<br>
-          Then use format: <code>Bearer {token}</code> or something to have extra info with <code>a long extra code block</code>
+          <br>
+          Fetch a token using the <code>POST /api/sign_in</code> endpoint.<br>
+          Then use the following format: <code>Bearer {token}</code>, or include additional information with <code>one extra code block</code>, <code>another extra code block</code>, <code>BLOCK 1</code>, <code>Second block</code>, <code>Third block</code>, and <code>Last block</code>.
         HTML
       }
     }

--- a/spec/dummy/app/api/api.rb
+++ b/spec/dummy/app/api/api.rb
@@ -76,7 +76,17 @@ class API < Grape::API
 
   add_swagger_documentation(
     security_definitions: {
-      api_key: { type: 'apiKey', name: 'Authorization', in: 'header' }
+      api_key: {
+        type: 'apiKey',
+        name: 'Authorization',
+        in: 'header',
+        description: <<~HTML
+          The default API authentication token.<br>
+          <br>
+          Fetch using the <code>POST /api/auth</code> endpoint.<br>
+          Then use format: <code>Bearer {token}</code> or someting to have extra info with <code>long extra code block</code>
+        HTML
+      }
     }
   )
 end

--- a/spec/features/swagger_spec.rb
+++ b/spec/features/swagger_spec.rb
@@ -115,8 +115,8 @@ describe 'Swagger' do
     find('.swagger-ui .scheme-container .btn.authorize', wait: 5).click
     expect(page).to have_css('.swagger-ui .dialog-ux .markdown code', wait: 5)
     page.evaluate_script(
-      "(function(){var c=document.querySelector('.swagger-ui .dialog-ux .markdown code');" \
-      "return c?window.getComputedStyle(c).display:null;})()"
+      '(function(){var c=document.querySelector(".swagger-ui .dialog-ux .markdown code");' \
+      'return c?window.getComputedStyle(c).display:null;})()'
     )
   end
 

--- a/spec/features/swagger_spec.rb
+++ b/spec/features/swagger_spec.rb
@@ -111,12 +111,12 @@ describe 'Swagger' do
     find_by_id('input_apiKey').set(value)
   end
 
-  def auth_dialog_code_display
+  def auth_dialog_code_bg
     find('.swagger-ui .scheme-container .btn.authorize', wait: 5).click
     expect(page).to have_css('.swagger-ui .dialog-ux .markdown code', wait: 5)
     page.evaluate_script(
       '(function(){var c=document.querySelector(".swagger-ui .dialog-ux .markdown code");' \
-      'return c?window.getComputedStyle(c).display:null;})()'
+      'return c?window.getComputedStyle(c).backgroundColor:null;})()'
     )
   end
 
@@ -897,7 +897,7 @@ describe 'Swagger' do
       it 'renders inline code in the auth dialog without background bleed in dark mode' do
         GrapeSwaggerRails.options.theme = 'dark'
         visit_swagger
-        expect(auth_dialog_code_display).to eq('inline-block')
+        expect(auth_dialog_code_bg).to eq('rgb(15, 23, 42)')
       end
     end
   end

--- a/spec/features/swagger_spec.rb
+++ b/spec/features/swagger_spec.rb
@@ -111,6 +111,15 @@ describe 'Swagger' do
     find_by_id('input_apiKey').set(value)
   end
 
+  def auth_dialog_code_display
+    find('.swagger-ui .scheme-container .btn.authorize', wait: 5).click
+    expect(page).to have_css('.swagger-ui .dialog-ux .markdown code', wait: 5)
+    page.evaluate_script(
+      "(function(){var c=document.querySelector('.swagger-ui .dialog-ux .markdown code');" \
+      "return c?window.getComputedStyle(c).display:null;})()"
+    )
+  end
+
   def open_operation(tag_id, operation_id)
     find("##{tag_id} .expand-operation").click
     find("##{operation_id} .opblock-control-arrow").click
@@ -888,18 +897,7 @@ describe 'Swagger' do
       it 'renders inline code in the auth dialog without background bleed in dark mode' do
         GrapeSwaggerRails.options.theme = 'dark'
         visit_swagger
-
-        find('.swagger-ui .scheme-container .btn.authorize', wait: 5).click
-        expect(page).to have_css('.swagger-ui .dialog-ux .markdown code', wait: 5)
-
-        code_display = page.evaluate_script(<<~JS)
-          (function() {
-            var code = document.querySelector('.swagger-ui .dialog-ux .markdown code');
-            return code ? window.getComputedStyle(code).display : null;
-          })()
-        JS
-        expect(page).to have_text('FREEZE', wait: 60)
-        expect(code_display).to eq('inline-block')
+        expect(auth_dialog_code_display).to eq('inline-block')
       end
     end
   end

--- a/spec/features/swagger_spec.rb
+++ b/spec/features/swagger_spec.rb
@@ -851,9 +851,8 @@ describe 'Swagger' do
       it 'serves the api_key security definition in the swagger document' do
         document = swagger_document
 
-        expect(document.fetch('securityDefinitions')).to eq(
-          'api_key' => { 'type' => 'apiKey', 'name' => 'Authorization',
-                         'in' => 'header' }
+        expect(document.fetch('securityDefinitions')).to include(
+          'api_key' => a_hash_including('type' => 'apiKey', 'name' => 'Authorization', 'in' => 'header')
         )
       end
 
@@ -884,6 +883,23 @@ describe 'Swagger' do
 
         expect(page).to have_css('#operations-foos-getApiFoos .opblock-summary', wait: 5)
         expect(page).to have_no_css('#operations-foos-getApiFoos .opblock-summary .authorization__btn')
+      end
+
+      it 'renders inline code in the auth dialog without background bleed in dark mode' do
+        GrapeSwaggerRails.options.theme = 'dark'
+        visit_swagger
+
+        find('.swagger-ui .scheme-container .btn.authorize', wait: 5).click
+        expect(page).to have_css('.swagger-ui .dialog-ux .markdown code', wait: 5)
+
+        code_display = page.evaluate_script(<<~JS)
+          (function() {
+            var code = document.querySelector('.swagger-ui .dialog-ux .markdown code');
+            return code ? window.getComputedStyle(code).display : null;
+          })()
+        JS
+        expect(page).to have_text('FREEZE', wait: 60)
+        expect(code_display).to eq('inline-block')
       end
     end
   end


### PR DESCRIPTION
Fix dark mode inline code bleed and Authorize button alignment.
Inline `<code>` elements in security scheme descriptions were overlapping adjacent text in dark mode - opaque background on `display: inline` caused vertical padding to bleed into neighbouring line-boxes. Also fixes the Authorize button's text/icon misalignment caused by Swagger UI's fragile float-based layout. 

<img width="697" height="541" alt="Screenshot 2026-07-08 at 15 38 55" src="https://github.com/user-attachments/assets/e0841740-d095-4803-9a56-a4c08698f897" />
